### PR TITLE
Applying style guide

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,5 +1,10 @@
+;;; .dir-locals.el --- metadata-tool Emacs configuration  -*- lexical-binding: t; -*-
+
+;; Author: Carlo Sciolla <carlo@session.it>
+;; Keywords: convenience
+
 ;;
-;; Copyright 2018 Fintech Open Source Foundation
+;; Copyright 2017 Fintech Open Source Foundation
 ;; SPDX-License-Identifier: Apache-2.0
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");;
@@ -15,26 +20,14 @@
 ;; limitations under the License.
 ;;
 
-(ns metadata-tool.exit-code)
+;;; Commentary:
+;; Define common rules for Emacs users when editing code of metadata-tool
 
-(def ^:private exit-code (atom 0))
+;;; Code:
 
-(defn set-exit-code
-  "Sets the exit code to at least the given value."
-  [new-exit-code]
-  (swap! exit-code max new-exit-code))
+((nil . (
+            (clojure-align-forms-automatically . t) ; enable vertical align
+         )))
 
-(defn set-warning
-  "Set a warning exit code (1)."
-  []
-  (set-exit-code 1))
-
-(defn set-error
-  "Set an error exit code (2)."
-  []
-  (set-exit-code 2))
-
-(defn get-exit-code
-  "Retrieves the current value of the exit code."
-  []
-  @exit-code)
+(provide '.dir-locals)
+;;; .dir-locals.el ends here

--- a/project.clj
+++ b/project.clj
@@ -16,38 +16,38 @@
 ;;
 
 (defproject org.finos/metadata-tool "0.1.0-SNAPSHOT"
-    :description          "A simple tool that provides various functions on Foundation metadata."
-    :url                  "https://github.com/finos/metadata-tool"
-    :license              {:name "Apache License, Version 2.0"
-                              :url  "http://www.apache.org/licenses/LICENSE-2.0"}
-    :min-lein-version     "2.7.1"
-    :repositories         [["sonatype-snapshots" {:url "https://oss.sonatype.org/content/groups/public" :snapshots true}]
-                              ["jitpack"            {:url "https://jitpack.io"                             :snapshots true}]]
-    :plugins              [[lein-licenses "0.2.2"]]
-    :dependencies         [[org.clojure/clojure                   "1.9.0"]
-                              [org.clojure/tools.cli                 "0.3.7"]
-                              [org.clojure/tools.logging             "0.4.1"]
-                              [ch.qos.logback/logback-classic        "1.2.3"]
-                              [org.slf4j/jcl-over-slf4j              "1.7.25"]
-                              [org.slf4j/log4j-over-slf4j            "1.7.25"]
-                              [org.slf4j/jul-to-slf4j                "1.7.25"]
-                              [cheshire                              "5.8.0"]
-                              [aero                                  "1.1.3"]
-                              [org.clojure/data.csv                  "0.1.4"]
-                              [mount                                 "0.1.12"]
-                              [enlive                                "1.1.6"]
-                              [hickory                               "0.7.1"]
-                              [lambdaisland/uri                      "1.1.0"]
-                              [com.github.grinnbearit/freemarker-clj "-SNAPSHOT"]
-                              [metosin/scjsv                         "0.4.1"]
-                              [clj-jgit                              "0.8.10" :exclusions [org.apache.httpcomponents/httpclient]]
-                              [irresponsible/tentacles               "0.6.2"]
-                              [cc.qbits/spandex                      "0.6.2" :exclusions [commons-logging org.apache.httpcomponents/httpcore-nio]]
-                              [com.draines/postal                    "2.0.2" :exclusions [commons-codec]]]
-    :managed-dependencies [;; The following dependencies are inherited but have conflicting or old versions, so we "pin" the versions here
-                              [joda-time/joda-time "2.10"]
-                              [clj-http            "3.9.0"]]
-    :profiles             {:dev     {:dependencies [[midje      "1.9.1"]]
-                                        :plugins      [[lein-midje "3.2.1"]]}
-                              :uberjar {:aot :all}}
-    :main ^:skip-aot metadata-tool.main)
+  :description          "A simple tool that provides various functions on Foundation metadata."
+  :url                  "https://github.com/finos/metadata-tool"
+  :license              {:name "Apache License, Version 2.0"
+                         :url  "http://www.apache.org/licenses/LICENSE-2.0"}
+  :min-lein-version     "2.7.1"
+  :repositories         [["sonatype-snapshots" {:url "https://oss.sonatype.org/content/groups/public" :snapshots true}]
+                         ["jitpack"            {:url "https://jitpack.io"                             :snapshots true}]]
+  :plugins              [[lein-licenses "0.2.2"]]
+  :dependencies         [[org.clojure/clojure                   "1.9.0"]
+                         [org.clojure/tools.cli                 "0.3.7"]
+                         [org.clojure/tools.logging             "0.4.1"]
+                         [ch.qos.logback/logback-classic        "1.2.3"]
+                         [org.slf4j/jcl-over-slf4j              "1.7.25"]
+                         [org.slf4j/log4j-over-slf4j            "1.7.25"]
+                         [org.slf4j/jul-to-slf4j                "1.7.25"]
+                         [cheshire                              "5.8.0"]
+                         [aero                                  "1.1.3"]
+                         [org.clojure/data.csv                  "0.1.4"]
+                         [mount                                 "0.1.12"]
+                         [enlive                                "1.1.6"]
+                         [hickory                               "0.7.1"]
+                         [lambdaisland/uri                      "1.1.0"]
+                         [com.github.grinnbearit/freemarker-clj "-SNAPSHOT"]
+                         [metosin/scjsv                         "0.4.1"]
+                         [clj-jgit                              "0.8.10" :exclusions [org.apache.httpcomponents/httpclient]]
+                         [irresponsible/tentacles               "0.6.2"]
+                         [cc.qbits/spandex                      "0.6.2" :exclusions [commons-logging org.apache.httpcomponents/httpcore-nio]]
+                         [com.draines/postal                    "2.0.2" :exclusions [commons-codec]]]
+  :managed-dependencies [;; The following dependencies are inherited but have conflicting or old versions, so we "pin" the versions here
+                         [joda-time/joda-time "2.10"]
+                         [clj-http            "3.9.0"]]
+  :profiles             {:dev     {:dependencies [[midje      "1.9.1"]]
+                                   :plugins      [[lein-midje "3.2.1"]]}
+                         :uberjar {:aot :all}}
+  :main ^:skip-aot metadata-tool.main)

--- a/project.clj
+++ b/project.clj
@@ -1,63 +1,53 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 
 (defproject org.finos/metadata-tool "0.1.0-SNAPSHOT"
-  :description          "A simple tool that provides various functions on Foundation metadata."
-  :url                  "https://github.com/finos/metadata-tool"
-  :license              {:name "Apache License, Version 2.0"
-                         :url  "http://www.apache.org/licenses/LICENSE-2.0"}
-  :min-lein-version     "2.7.1"
-  :repositories         [
-                          ["sonatype-snapshots" {:url "https://oss.sonatype.org/content/groups/public" :snapshots true}]
-                          ["jitpack"            {:url "https://jitpack.io"                             :snapshots true}]
-                        ]
-  :plugins              [
-                          [lein-licenses "0.2.2"]
-                        ]
-  :dependencies         [
-                          [org.clojure/clojure                   "1.9.0"]
-                          [org.clojure/tools.cli                 "0.3.7"]
-                          [org.clojure/tools.logging             "0.4.1"]
-                          [ch.qos.logback/logback-classic        "1.2.3"]
-                          [org.slf4j/jcl-over-slf4j              "1.7.25"]
-                          [org.slf4j/log4j-over-slf4j            "1.7.25"]
-                          [org.slf4j/jul-to-slf4j                "1.7.25"]
-                          [cheshire                              "5.8.0"]
-                          [aero                                  "1.1.3"]
-                          [org.clojure/data.csv                  "0.1.4"]
-                          [mount                                 "0.1.12"]
-                          [enlive                                "1.1.6"]
-                          [hickory                               "0.7.1"]
-                          [lambdaisland/uri                      "1.1.0"]
-                          [com.github.grinnbearit/freemarker-clj "-SNAPSHOT"]
-                          [metosin/scjsv                         "0.4.1"]
-                          [clj-jgit                              "0.8.10" :exclusions [org.apache.httpcomponents/httpclient]]
-                          [irresponsible/tentacles               "0.6.2"]
-                          [cc.qbits/spandex                      "0.6.2" :exclusions [commons-logging org.apache.httpcomponents/httpcore-nio]]
-                          [com.draines/postal                    "2.0.2" :exclusions [commons-codec]]
-                        ]
-  :managed-dependencies [
-                          ; The following dependencies are inherited but have conflicting or old versions, so we "pin" the versions here
-                          [joda-time/joda-time "2.10"]
-                          [clj-http            "3.9.0"]
-                        ]
-  :profiles             {
-                          :dev     {:dependencies [[midje      "1.9.1"]]
-                                    :plugins      [[lein-midje "3.2.1"]]}
-                          :uberjar {:aot :all}
-                        }
-  :main ^:skip-aot metadata-tool.main)
+    :description          "A simple tool that provides various functions on Foundation metadata."
+    :url                  "https://github.com/finos/metadata-tool"
+    :license              {:name "Apache License, Version 2.0"
+                              :url  "http://www.apache.org/licenses/LICENSE-2.0"}
+    :min-lein-version     "2.7.1"
+    :repositories         [["sonatype-snapshots" {:url "https://oss.sonatype.org/content/groups/public" :snapshots true}]
+                              ["jitpack"            {:url "https://jitpack.io"                             :snapshots true}]]
+    :plugins              [[lein-licenses "0.2.2"]]
+    :dependencies         [[org.clojure/clojure                   "1.9.0"]
+                              [org.clojure/tools.cli                 "0.3.7"]
+                              [org.clojure/tools.logging             "0.4.1"]
+                              [ch.qos.logback/logback-classic        "1.2.3"]
+                              [org.slf4j/jcl-over-slf4j              "1.7.25"]
+                              [org.slf4j/log4j-over-slf4j            "1.7.25"]
+                              [org.slf4j/jul-to-slf4j                "1.7.25"]
+                              [cheshire                              "5.8.0"]
+                              [aero                                  "1.1.3"]
+                              [org.clojure/data.csv                  "0.1.4"]
+                              [mount                                 "0.1.12"]
+                              [enlive                                "1.1.6"]
+                              [hickory                               "0.7.1"]
+                              [lambdaisland/uri                      "1.1.0"]
+                              [com.github.grinnbearit/freemarker-clj "-SNAPSHOT"]
+                              [metosin/scjsv                         "0.4.1"]
+                              [clj-jgit                              "0.8.10" :exclusions [org.apache.httpcomponents/httpclient]]
+                              [irresponsible/tentacles               "0.6.2"]
+                              [cc.qbits/spandex                      "0.6.2" :exclusions [commons-logging org.apache.httpcomponents/httpcore-nio]]
+                              [com.draines/postal                    "2.0.2" :exclusions [commons-codec]]]
+    :managed-dependencies [;; The following dependencies are inherited but have conflicting or old versions, so we "pin" the versions here
+                              [joda-time/joda-time "2.10"]
+                              [clj-http            "3.9.0"]]
+    :profiles             {:dev     {:dependencies [[midje      "1.9.1"]]
+                                        :plugins      [[lein-midje "3.2.1"]]}
+                              :uberjar {:aot :all}}
+    :main ^:skip-aot metadata-tool.main)

--- a/src/metadata_tool/config.clj
+++ b/src/metadata_tool/config.clj
@@ -16,23 +16,22 @@
 ;;
 
 (ns metadata-tool.config
-  (:require
-    [clojure.string  :as s]
-    [clojure.java.io :as io]
-    [mount.core      :as mnt :refer [defstate]]))
+  (:require [clojure.string  :as s]
+            [clojure.java.io :as io]
+            [mount.core      :as mnt :refer [defstate]]))
 
 ;; Because java.util.logging is a hot mess
 (org.slf4j.bridge.SLF4JBridgeHandler/removeHandlersForRootLogger)
 (org.slf4j.bridge.SLF4JBridgeHandler/install)
 
 (defstate config
-          :start (mnt/args))
+  :start (mnt/args))
 
 (defstate temp-directory
-  :start (let [result       (if (s/blank? (:temp-dir config))
-                              (System/getProperty "java.io.tmpdir")
-                              (:temp-dir config))
-                result-as-f (io/file result)]
+  :start (let [result      (if (s/blank? (:temp-dir config))
+                             (System/getProperty "java.io.tmpdir")
+                             (:temp-dir config))
+               result-as-f (io/file result)]
            (if (.exists result-as-f)
              (if (.isDirectory result-as-f)
                (if (.canWrite result-as-f)

--- a/src/metadata_tool/config.clj
+++ b/src/metadata_tool/config.clj
@@ -1,26 +1,27 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 
 (ns metadata-tool.config
-  (:require [clojure.string  :as s]
-            [clojure.java.io :as io]
-            [mount.core      :as mnt :refer [defstate]]))
+  (:require
+    [clojure.string  :as s]
+    [clojure.java.io :as io]
+    [mount.core      :as mnt :refer [defstate]]))
 
-; Because java.util.logging is a hot mess
+;; Because java.util.logging is a hot mess
 (org.slf4j.bridge.SLF4JBridgeHandler/removeHandlersForRootLogger)
 (org.slf4j.bridge.SLF4JBridgeHandler/install)
 
@@ -28,15 +29,14 @@
           :start (mnt/args))
 
 (defstate temp-directory
-          :start (let [result      (if (s/blank? (:temp-dir config))
-                                     (System/getProperty "java.io.tmpdir")
-                                     (:temp-dir config))
-                       result-as-f (io/file result)]
-                   (if (.exists result-as-f)
-                     (if (.isDirectory result-as-f)
-                       (if (.canWrite result-as-f)
-                         result
-                         (throw (Exception. (str "Temp directory " result " is not writable."))))
-                       (throw (Exception. (str "Temp directory " result " is not a directory."))))
-                     (throw (Exception. (str "Temp directory " result " does not exist."))))))
-
+  :start (let [result       (if (s/blank? (:temp-dir config))
+                              (System/getProperty "java.io.tmpdir")
+                              (:temp-dir config))
+                result-as-f (io/file result)]
+           (if (.exists result-as-f)
+             (if (.isDirectory result-as-f)
+               (if (.canWrite result-as-f)
+                 result
+                 (throw (Exception. (str "Temp directory " result " is not writable."))))
+               (throw (Exception. (str "Temp directory " result " is not a directory."))))
+             (throw (Exception. (str "Temp directory " result " does not exist."))))))

--- a/src/metadata_tool/core.clj
+++ b/src/metadata_tool/core.clj
@@ -1,31 +1,31 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns metadata-tool.core
-  (:require [clojure.string                 :as s]
-            [metadata-tool.tools.checkers   :as tch]
-            [metadata-tool.tools.listers    :as tls]
-            [metadata-tool.tools.generators :as tgn]
-            [metadata-tool.tools.reports    :as trp]))
+  (:require
+    [clojure.string                 :as s]
+    [metadata-tool.tools.checkers   :as tch]
+    [metadata-tool.tools.listers    :as tls]
+    [metadata-tool.tools.generators :as tgn]
+    [metadata-tool.tools.reports    :as trp]))
 
 
-; Map of (lowercase) tool names to tool fns
 (def ^:private tools
-  {
-    "check-local"                    tch/check-local
+  "Map of (lowercase) tool names to tool fns"
+  { "check-local"                    tch/check-local
     "check"                          tch/check
     "list-schemas"                   tls/list-schemas
     "list-people-with-clas"          tls/list-people-with-clas
@@ -35,8 +35,7 @@
     "gen-bitergia-project-data"      tgn/gen-bitergia-project-data
     "gen-clabot-whitelist"           tgn/gen-clabot-whitelist
     "gen-catalogue-data"             tgn/gen-catalogue-data
-    "email-pmc-reports"              trp/email-pmc-reports
-  })
+    "email-pmc-reports"              trp/email-pmc-reports})
 
 (def tool-names (sort (keys tools)))
 

--- a/src/metadata_tool/core.clj
+++ b/src/metadata_tool/core.clj
@@ -14,28 +14,28 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
+
 (ns metadata-tool.core
-  (:require
-    [clojure.string                 :as s]
-    [metadata-tool.tools.checkers   :as tch]
-    [metadata-tool.tools.listers    :as tls]
-    [metadata-tool.tools.generators :as tgn]
-    [metadata-tool.tools.reports    :as trp]))
+  (:require [clojure.string                 :as s]
+            [metadata-tool.tools.checkers   :as tch]
+            [metadata-tool.tools.listers    :as tls]
+            [metadata-tool.tools.generators :as tgn]
+            [metadata-tool.tools.reports    :as trp]))
 
 
 (def ^:private tools
   "Map of (lowercase) tool names to tool fns"
-  { "check-local"                    tch/check-local
-    "check"                          tch/check
-    "list-schemas"                   tls/list-schemas
-    "list-people-with-clas"          tls/list-people-with-clas
-    "gen-meeting-roster-data"        tgn/gen-meeting-roster-data
-    "gen-bitergia-affiliation-data"  tgn/gen-bitergia-affiliation-data
-    "gen-bitergia-organization-data" tgn/gen-bitergia-organization-data
-    "gen-bitergia-project-data"      tgn/gen-bitergia-project-data
-    "gen-clabot-whitelist"           tgn/gen-clabot-whitelist
-    "gen-catalogue-data"             tgn/gen-catalogue-data
-    "email-pmc-reports"              trp/email-pmc-reports})
+  {"check-local"                    tch/check-local
+   "check"                          tch/check
+   "list-schemas"                   tls/list-schemas
+   "list-people-with-clas"          tls/list-people-with-clas
+   "gen-meeting-roster-data"        tgn/gen-meeting-roster-data
+   "gen-bitergia-affiliation-data"  tgn/gen-bitergia-affiliation-data
+   "gen-bitergia-organization-data" tgn/gen-bitergia-organization-data
+   "gen-bitergia-project-data"      tgn/gen-bitergia-project-data
+   "gen-clabot-whitelist"           tgn/gen-clabot-whitelist
+   "gen-catalogue-data"             tgn/gen-catalogue-data
+   "email-pmc-reports"              trp/email-pmc-reports})
 
 (def tool-names (sort (keys tools)))
 

--- a/src/metadata_tool/main.clj
+++ b/src/metadata_tool/main.clj
@@ -1,62 +1,63 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns metadata-tool.main
-  (:require [clojure.string          :as s]
-            [clojure.java.io         :as io]
-            [clojure.stacktrace      :as st]
-            [clojure.tools.cli       :as cli]
-            [clojure.tools.logging   :as log]
-            [aero.core               :as a]
-            [mount.core              :as mnt :refer [defstate]]
-            [metadata-tool.exit-code :as ec]
-            [metadata-tool.config    :as cfg]
-            [metadata-tool.core      :as c])
+  (:require
+    [clojure.string          :as s]
+    [clojure.java.io         :as io]
+    [clojure.stacktrace      :as st]
+    [clojure.tools.cli       :as cli]
+    [clojure.tools.logging   :as log]
+    [aero.core               :as a]
+    [mount.core              :as mnt :refer [defstate]]
+    [metadata-tool.exit-code :as ec]
+    [metadata-tool.config    :as cfg]
+    [metadata-tool.core      :as c])
   (:gen-class))
 
 (def ^:private cli-opts
   [["-c" "--config-file FILE" "Path of configuration file (optional, defaults to 'config.edn' in the classpath)"
-    :validate [#(.exists  (io/file %)) "Must exist"
-               #(.isFile  (io/file %)) "Must be a file"
-               #(.canRead (io/file %)) "Must be readable"]]
-   ["-m" "--metadata-directory DIRECTORY" "Path of local metadata directory (optional, metadata will be checked out from GitHub if not specified)"
-    :validate [#(.exists      (io/file %)) "Must exist"
-               #(.isDirectory (io/file %)) "Must be a directory"
-               #(.canRead     (io/file %)) "Must be readable"]]
-   ["-r" "--github-revision REVISION" "GitHub revision of the metadata repository to checkout and use (optional, defaults to latest)"]
-   [nil  "--email-override" "Overrides the default email behaviour of using a test email address for all outbound emails (DO NOT USE UNLESS YOU REALLY KNOW WHAT YOU'RE DOING!)."]
-   ["-h" "--help"]])
+     :validate [#(.exists   (io/file %)) "Must exist"
+                 #(.isFile  (io/file %)) "Must be a file"
+                 #(.canRead (io/file %)) "Must be readable"]]
+    ["-m" "--metadata-directory DIRECTORY" "Path of local metadata directory (optional, metadata will be checked out from GitHub if not specified)"
+      :validate [ #(.exists      (io/file %)) "Must exist"
+                  #(.isDirectory (io/file %)) "Must be a directory"
+                  #(.canRead     (io/file %)) "Must be readable"]]
+    ["-r" "--github-revision REVISION" "GitHub revision of the metadata repository to checkout and use (optional, defaults to latest)"]
+    [nil  "--email-override" "Overrides the default email behaviour of using a test email address for all outbound emails (DO NOT USE UNLESS YOU REALLY KNOW WHAT YOU'RE DOING!)."]
+    ["-h" "--help"]])
 
 (defn- usage
   [options-summary]
   (s/join
     \newline
     ["Runs one or more metadata tools."
-     ""
-     "Usage: metadata-tool [options] tool [tool] ..."
-     ""
-     "Options:"
-     options-summary
-     ""
-     (str "Available tools:\n\t" (s/join "\n\t" c/tool-names))]))
+      ""
+      "Usage: metadata-tool [options] tool [tool] ..."
+      ""
+      "Options:"
+      options-summary
+      ""
+      (str "Available tools:\n\t" (s/join "\n\t" c/tool-names))]))
 
 (defn- error-message
   [errors]
   (str "The following errors occurred while parsing your command:\n\n"
-       (s/join \newline errors)))
+    (s/join \newline errors)))
 
 (defn- exit
   ([exit-code] (exit exit-code nil))
@@ -79,17 +80,17 @@
         :else              (mnt/with-args (assoc (if-let [config-file (:config-file options)]
                                                    (a/read-config config-file)
                                                    (a/read-config (io/resource "config.edn")))
-                                                 :metadata-directory (:metadata-directory options)
-                                                 :github-revision    (:github-revision    options)
-                                                 :email-override     (boolean (:email-override options)))))
+                                            :metadata-directory (:metadata-directory options)
+                                            :github-revision    (:github-revision    options)
+                                            :email-override     (boolean (:email-override options)))))
       (let [tools-to-run (map s/lower-case arguments)]
         (if (every? (set c/tool-names) tools-to-run)
           (try
             (mnt/start)
             (doall (map #(do (log/info "Running tool" %)
-                             (c/run-tool %)
-                             (flush))
-                        arguments))
+                           (c/run-tool %)
+                           (flush))
+                     arguments))
             (finally
               (mnt/stop)))
           (exit 1 (str "Unknown tool - available tools are:\n\t" (s/join "\n\t" c/tool-names))))))

--- a/src/metadata_tool/main.clj
+++ b/src/metadata_tool/main.clj
@@ -14,59 +14,58 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
+
 (ns metadata-tool.main
-  (:require
-    [clojure.string          :as s]
-    [clojure.java.io         :as io]
-    [clojure.stacktrace      :as st]
-    [clojure.tools.cli       :as cli]
-    [clojure.tools.logging   :as log]
-    [aero.core               :as a]
-    [mount.core              :as mnt :refer [defstate]]
-    [metadata-tool.exit-code :as ec]
-    [metadata-tool.config    :as cfg]
-    [metadata-tool.core      :as c])
+  (:require [clojure.string          :as s]
+            [clojure.java.io         :as io]
+            [clojure.stacktrace      :as st]
+            [clojure.tools.cli       :as cli]
+            [clojure.tools.logging   :as log]
+            [aero.core               :as a]
+            [mount.core              :as mnt :refer [defstate]]
+            [metadata-tool.exit-code :as ec]
+            [metadata-tool.config    :as cfg]
+            [metadata-tool.core      :as c])
   (:gen-class))
 
 (def ^:private cli-opts
   [["-c" "--config-file FILE" "Path of configuration file (optional, defaults to 'config.edn' in the classpath)"
-     :validate [#(.exists   (io/file %)) "Must exist"
-                 #(.isFile  (io/file %)) "Must be a file"
-                 #(.canRead (io/file %)) "Must be readable"]]
-    ["-m" "--metadata-directory DIRECTORY" "Path of local metadata directory (optional, metadata will be checked out from GitHub if not specified)"
-      :validate [ #(.exists      (io/file %)) "Must exist"
-                  #(.isDirectory (io/file %)) "Must be a directory"
-                  #(.canRead     (io/file %)) "Must be readable"]]
-    ["-r" "--github-revision REVISION" "GitHub revision of the metadata repository to checkout and use (optional, defaults to latest)"]
-    [nil  "--email-override" "Overrides the default email behaviour of using a test email address for all outbound emails (DO NOT USE UNLESS YOU REALLY KNOW WHAT YOU'RE DOING!)."]
-    ["-h" "--help"]])
+    :validate [#(.exists   (io/file %)) "Must exist"
+               #(.isFile  (io/file %)) "Must be a file"
+               #(.canRead (io/file %)) "Must be readable"]]
+   ["-m" "--metadata-directory DIRECTORY" "Path of local metadata directory (optional, metadata will be checked out from GitHub if not specified)"
+    :validate [ #(.exists      (io/file %)) "Must exist"
+               #(.isDirectory (io/file %)) "Must be a directory"
+               #(.canRead     (io/file %)) "Must be readable"]]
+   ["-r" "--github-revision REVISION" "GitHub revision of the metadata repository to checkout and use (optional, defaults to latest)"]
+   [nil  "--email-override" "Overrides the default email behaviour of using a test email address for all outbound emails (DO NOT USE UNLESS YOU REALLY KNOW WHAT YOU'RE DOING!)."]
+   ["-h" "--help"]])
 
 (defn- usage
   [options-summary]
-  (s/join
-    \newline
-    ["Runs one or more metadata tools."
-      ""
-      "Usage: metadata-tool [options] tool [tool] ..."
-      ""
-      "Options:"
-      options-summary
-      ""
-      (str "Available tools:\n\t" (s/join "\n\t" c/tool-names))]))
+  (s/join \newline
+          ["Runs one or more metadata tools."
+           ""
+           "Usage: metadata-tool [options] tool [tool] ..."
+           ""
+           "Options:"
+           options-summary
+           ""
+           (str "Available tools:\n\t" (s/join "\n\t" c/tool-names))]))
 
 (defn- error-message
   [errors]
   (str "The following errors occurred while parsing your command:\n\n"
-    (s/join \newline errors)))
+       (s/join \newline errors)))
 
 (defn- exit
   ([exit-code] (exit exit-code nil))
   ([exit-code message]
-    (ec/set-exit-code exit-code)
-    (when-not (s/blank? message)
-      (println message))
-    (flush)
-    (System/exit (ec/get-exit-code))))
+   (ec/set-exit-code exit-code)
+   (when-not (s/blank? message)
+     (println message))
+   (flush)
+   (System/exit (ec/get-exit-code))))
 
 (defn -main
   [& args]
@@ -80,17 +79,17 @@
         :else              (mnt/with-args (assoc (if-let [config-file (:config-file options)]
                                                    (a/read-config config-file)
                                                    (a/read-config (io/resource "config.edn")))
-                                            :metadata-directory (:metadata-directory options)
-                                            :github-revision    (:github-revision    options)
-                                            :email-override     (boolean (:email-override options)))))
+                                                 :metadata-directory (:metadata-directory options)
+                                                 :github-revision    (:github-revision    options)
+                                                 :email-override     (boolean (:email-override options)))))
       (let [tools-to-run (map s/lower-case arguments)]
         (if (every? (set c/tool-names) tools-to-run)
           (try
             (mnt/start)
             (doall (map #(do (log/info "Running tool" %)
-                           (c/run-tool %)
-                           (flush))
-                     arguments))
+                             (c/run-tool %)
+                             (flush))
+                        arguments))
             (finally
               (mnt/stop)))
           (exit 1 (str "Unknown tool - available tools are:\n\t" (s/join "\n\t" c/tool-names))))))

--- a/src/metadata_tool/sources/bitergia.clj
+++ b/src/metadata_tool/sources/bitergia.clj
@@ -1,26 +1,27 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns metadata-tool.sources.bitergia
-  (:require [clojure.string        :as s]
-            [clojure.tools.logging :as log]
-            [clojure.set           :as set]
-            [mount.core            :as mnt :refer [defstate]]
-            [qbits.spandex         :as es]
-            [metadata-tool.config  :as cfg]))
+  (:require
+    [clojure.string        :as s]
+    [clojure.tools.logging :as log]
+    [clojure.set           :as set]
+    [mount.core            :as mnt :refer [defstate]]
+    [qbits.spandex         :as es]
+    [metadata-tool.config  :as cfg]))
 
 (def ^:private bitergia-url                 "https://symphonyoss.biterg.io")   ; Note: no trailing / or spandex will assplode!
 (def ^:private git-search-endpoint          "/data/git/_search")
@@ -34,30 +35,24 @@
                             mailing-list-search-endpoint })
 
 (defstate client
-          :start (es/client {:hosts       [bitergia-url]
-                             :http-client {:basic-auth {:user (:username (:bitergia cfg/config)) :password (:password (:bitergia cfg/config))}}}))
+  :start (es/client { :hosts       [bitergia-url]
+                      :http-client {:basic-auth { :user     (:username (:bitergia cfg/config))
+                                                  :password (:password (:bitergia cfg/config))}}}))
 
 (def ^:private query-all-projects
   "This ElasticSearch query returns all projects known to Bitergia."
   { :size 0
-    :aggs {
-      :projects {
-        :terms {
-          :field "project"
-          :size  1000
-        }
-      }
-    }
-  })
+    :aggs {:projects {:terms { :field "project"
+                               :size  1000}}}})
 
 (defn- all-projects-for-endpoint
   "Returns the names of all known projects at the given endpoint."
   [endpoint]
   (if endpoint
     (set (map #(s/trim (:key %))
-              (:buckets (:projects (:aggregations (:body (es/request client { :url    endpoint
-                                                                              :method :get
-                                                                              :body   query-all-projects } )))))))))
+           (:buckets (:projects (:aggregations (:body (es/request client { :url    endpoint
+                                                                           :method :get
+                                                                           :body   query-all-projects } )))))))))
 
 (defn all-projects
   "Returns the set of project names with activity tracked in Bitergia."
@@ -68,34 +63,11 @@
 (defn- recent-projects-query
   "Returns an ElasticSearch query for all recent projects (those that have had a commit in the last threshold-in-days)."
   [threshold-in-days]
-  { :size 0
-    :query {
-      :constant_score {
-         :filter {
-            :range {
-               :commit_date {
-                  :gte (str "now-" threshold-in-days "d/d")
-               }
-            }
-         }
-      }
-    }
-    :aggs {
-      :projects {
-        :terms {
-          :field "project"
-          :size  1000
-        }
-        :aggs {
-          :last_commit_date {
-            :max {
-              :field "commit_date"
-            }
-          }
-        }
-      }
-    }
-  })
+  { :size  0
+    :query {:constant_score {:filter {:range {:commit_date {:gte (str "now-" threshold-in-days "d/d")}}}}}
+    :aggs  {:projects {:terms { :field "project"
+                                :size  1000}
+                        :aggs {:last_commit_date {:max {:field "commit_date"}}}}}})
 
 (defn- recently-active-projects-for-endpoint
   [endpoint threshold-in-days]
@@ -123,44 +95,12 @@
 (defn- old-github-issues-query
   "Returns the ElasticSearch query for old GitHub issues or PRs."
   [threshold-in-days pr?]
-  { :size 0
-    :query {
-      :constant_score {
-         :filter {
-            :bool {
-              :must [ {
-                  :range {
-                     :time_open_days {
-                        :gte (str threshold-in-days)
-                     }
-                  }
-                }
-                {
-                  :term {
-                     :pull_request pr?
-                  }
-                }
-              ]
-            }
-         }
-      }
-    }
-    :aggs {
-      :projects {
-        :terms {
-          :field "project"
-          :size  1000
-        }
-        :aggs {
-          :last_commit_date {
-            :max {
-              :field "time_open_days"
-            }
-          }
-        }
-      }
-    }
-  })
+  { :size  0
+    :query {:constant_score {:filter {:bool {:must [ {:range {:time_open_days {:gte (str threshold-in-days)}}}
+                                                     {:term {:pull_request pr?}}]}}}}
+    :aggs  {:projects {:terms { :field "project"
+                                :size  1000}
+                        :aggs {:last_commit_date {:max {:field "time_open_days"}}}}}})
 
 (defn projects-with-old-prs
   "Returns the set of project names with PRs older than threshold-in-days."

--- a/src/metadata_tool/sources/bitergia.clj
+++ b/src/metadata_tool/sources/bitergia.clj
@@ -14,14 +14,14 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
+
 (ns metadata-tool.sources.bitergia
-  (:require
-    [clojure.string        :as s]
-    [clojure.tools.logging :as log]
-    [clojure.set           :as set]
-    [mount.core            :as mnt :refer [defstate]]
-    [qbits.spandex         :as es]
-    [metadata-tool.config  :as cfg]))
+  (:require [clojure.string        :as s]
+            [clojure.tools.logging :as log]
+            [clojure.set           :as set]
+            [mount.core            :as mnt :refer [defstate]]
+            [qbits.spandex         :as es]
+            [metadata-tool.config  :as cfg]))
 
 (def ^:private bitergia-url                 "https://symphonyoss.biterg.io")   ; Note: no trailing / or spandex will assplode!
 (def ^:private git-search-endpoint          "/data/git/_search")
@@ -29,30 +29,30 @@
 (def ^:private wiki-search-endpoint         "/data/confluence/_search")
 (def ^:private mailing-list-search-endpoint "/data/mbox/_search")
 
-(def ^:private endpoints #{ git-search-endpoint
-                            github-search-endpoint
-                            wiki-search-endpoint
-                            mailing-list-search-endpoint })
+(def ^:private endpoints #{git-search-endpoint
+                           github-search-endpoint
+                           wiki-search-endpoint
+                           mailing-list-search-endpoint})
 
 (defstate client
-  :start (es/client { :hosts       [bitergia-url]
-                      :http-client {:basic-auth { :user     (:username (:bitergia cfg/config))
-                                                  :password (:password (:bitergia cfg/config))}}}))
+  :start (es/client {:hosts       [bitergia-url]
+                     :http-client {:basic-auth {:user     (:username (:bitergia cfg/config))
+                                                :password (:password (:bitergia cfg/config))}}}))
 
 (def ^:private query-all-projects
   "This ElasticSearch query returns all projects known to Bitergia."
-  { :size 0
-    :aggs {:projects {:terms { :field "project"
-                               :size  1000}}}})
+  {:size 0
+   :aggs {:projects {:terms { :field "project"
+                             :size   1000}}}})
 
 (defn- all-projects-for-endpoint
   "Returns the names of all known projects at the given endpoint."
   [endpoint]
   (if endpoint
     (set (map #(s/trim (:key %))
-           (:buckets (:projects (:aggregations (:body (es/request client { :url    endpoint
-                                                                           :method :get
-                                                                           :body   query-all-projects } )))))))))
+              (:buckets (:projects (:aggregations (:body (es/request client {:url    endpoint
+                                                                             :method :get
+                                                                             :body   query-all-projects})))))))))
 
 (defn all-projects
   "Returns the set of project names with activity tracked in Bitergia."
@@ -63,23 +63,23 @@
 (defn- recent-projects-query
   "Returns an ElasticSearch query for all recent projects (those that have had a commit in the last threshold-in-days)."
   [threshold-in-days]
-  { :size  0
-    :query {:constant_score {:filter {:range {:commit_date {:gte (str "now-" threshold-in-days "d/d")}}}}}
-    :aggs  {:projects {:terms { :field "project"
-                                :size  1000}
-                        :aggs {:last_commit_date {:max {:field "commit_date"}}}}}})
+  {:size  0
+   :query {:constant_score {:filter {:range {:commit_date {:gte (str "now-" threshold-in-days "d/d")}}}}}
+   :aggs  {:projects {:terms {:field "project"
+                              :size  1000}
+                      :aggs  {:last_commit_date {:max {:field "commit_date"}}}}}})
 
 (defn- recently-active-projects-for-endpoint
   [endpoint threshold-in-days]
   (if endpoint
     (set
-      (map #(s/trim (:key %))
-           (:buckets
-             (:projects
-               (:aggregations
-                 (:body (es/request client { :url    endpoint
-                                             :method :get
-                                             :body   (recent-projects-query threshold-in-days) } )))))))))
+     (map #(s/trim (:key %))
+          (:buckets
+           (:projects
+            (:aggregations
+             (:body (es/request client {:url    endpoint
+                                        :method :get
+                                        :body   (recent-projects-query threshold-in-days)})))))))))
 
 (defn recently-active-projects
   "Returns the set of recently active project names (those with activity in any data source in the last threshold-in-days)."
@@ -95,25 +95,25 @@
 (defn- old-github-issues-query
   "Returns the ElasticSearch query for old GitHub issues or PRs."
   [threshold-in-days pr?]
-  { :size  0
-    :query {:constant_score {:filter {:bool {:must [ {:range {:time_open_days {:gte (str threshold-in-days)}}}
-                                                     {:term {:pull_request pr?}}]}}}}
-    :aggs  {:projects {:terms { :field "project"
-                                :size  1000}
-                        :aggs {:last_commit_date {:max {:field "time_open_days"}}}}}})
+  {:size  0
+   :query {:constant_score {:filter {:bool {:must [{:range {:time_open_days {:gte (str threshold-in-days)}}}
+                                                   {:term {:pull_request pr?}}]}}}}
+   :aggs  {:projects {:terms {:field "project"
+                              :size  1000}
+                      :aggs  {:last_commit_date {:max {:field "time_open_days"}}}}}})
 
 (defn projects-with-old-prs
   "Returns the set of project names with PRs older than threshold-in-days."
   [threshold-in-days]
   (set (map #(s/trim (:key %))
-            (:buckets (:projects (:aggregations (:body (es/request client { :url    github-search-endpoint
-                                                                            :method :get
-                                                                            :body   (old-github-issues-query threshold-in-days true) } ))))))))
+            (:buckets (:projects (:aggregations (:body (es/request client {:url    github-search-endpoint
+                                                                           :method :get
+                                                                           :body   (old-github-issues-query threshold-in-days true)}))))))))
 
 (defn projects-with-old-issues
   "Returns the set of project names with issues older than threshold-in-days."
   [threshold-in-days]
   (set (map #(s/trim (:key %))
-            (:buckets (:projects (:aggregations (:body (es/request client { :url    github-search-endpoint
-                                                                            :method :get
-                                                                            :body   (old-github-issues-query threshold-in-days false) } ))))))))
+            (:buckets (:projects (:aggregations (:body (es/request client {:url    github-search-endpoint
+                                                                           :method :get
+                                                                           :body   (old-github-issues-query threshold-in-days false)}))))))))

--- a/src/metadata_tool/sources/confluence.clj
+++ b/src/metadata_tool/sources/confluence.clj
@@ -1,57 +1,57 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
 (ns metadata-tool.sources.confluence
-    (:require [clojure.string        :as s]
-              [clj-http.client       :as http]
-              [clj-http.conn-mgr     :as conn]
-              [metadata-tool.config  :as cfg]
-              ))
+  (:require
+    [clojure.string        :as s]
+    [clj-http.client       :as http]
+    [clj-http.conn-mgr     :as conn]
+    [metadata-tool.config  :as cfg]))
 
 (def cm (conn/make-reusable-conn-manager {}))
+
 (defn client []
-    (:http-client
-        (http/get (:host (:confluence cfg/config)) {
-            :connection-manager cm 
-            :cache true})))
+  (:http-client
+    (http/get (:host (:confluence cfg/config)) { :connection-manager cm
+                                                 :cache              true})))
 
 (defn cget [& args]
-    (http/get (str (:host (:confluence cfg/config)) "/wiki/rest/api/" (apply str args)) {
-        :basic-auth [
-            (:username (:confluence cfg/config))
-            (:password (:confluence cfg/config))]
-        :connection-manager cm 
-        :http-client (client)
-        :cache true
-        :as :json}))
+  (http/get (str (:host (:confluence cfg/config)) "/wiki/rest/api/" (apply str args))
+    {:basic-auth          [ (:username (:confluence cfg/config))
+                            (:password (:confluence cfg/config))]
+      :connection-manager cm
+      :http-client        (client)
+      :cache              true
+      :as                 :json}))
 
 (defn page-id
-    [url]
-    (nth 
-        (s/split url #"/") 4))
+  [url]
+  (nth
+    (s/split url #"/") 4))
 
 (defn content
-    [id]
-    (:value (:storage (:body (:body 
-        (cget "content/" id "?expand=body.storage"))))))
+  [id]
+  (:value (:storage (:body (:body
+                             (cget "content/" id "?expand=body.storage"))))))
 
 (defn children
-    [id]
-    (try
-        (:results (:body (cget "content/" id "/child/page")))
-        ; TODO - check Exception status code (clj-http)
-        ; tried with (:status (:data e))
-        (catch Exception e [])))
+  [id]
+  (try
+    (:results (:body (cget "content/" id "/child/page")))
+    ;; TODO - check Exception status code (clj-http)
+    ;; tried with (:status (:data e))
+    (catch Exception e [])))

--- a/src/metadata_tool/sources/confluence.clj
+++ b/src/metadata_tool/sources/confluence.clj
@@ -16,37 +16,36 @@
 ;;
 
 (ns metadata-tool.sources.confluence
-  (:require
-    [clojure.string        :as s]
-    [clj-http.client       :as http]
-    [clj-http.conn-mgr     :as conn]
-    [metadata-tool.config  :as cfg]))
+  (:require [clojure.string        :as s]
+            [clj-http.client       :as http]
+            [clj-http.conn-mgr     :as conn]
+            [metadata-tool.config  :as cfg]))
 
 (def cm (conn/make-reusable-conn-manager {}))
 
 (defn client []
   (:http-client
-    (http/get (:host (:confluence cfg/config)) { :connection-manager cm
-                                                 :cache              true})))
+   (http/get (:host (:confluence cfg/config)) {:connection-manager cm
+                                               :cache              true})))
 
 (defn cget [& args]
   (http/get (str (:host (:confluence cfg/config)) "/wiki/rest/api/" (apply str args))
-    {:basic-auth          [ (:username (:confluence cfg/config))
-                            (:password (:confluence cfg/config))]
-      :connection-manager cm
-      :http-client        (client)
-      :cache              true
-      :as                 :json}))
+            {:basic-auth         [(:username (:confluence cfg/config))
+                                  (:password (:confluence cfg/config))]
+             :connection-manager cm
+             :http-client        (client)
+             :cache              true
+             :as                 :json}))
 
 (defn page-id
   [url]
   (nth
-    (s/split url #"/") 4))
+   (s/split url #"/") 4))
 
 (defn content
   [id]
   (:value (:storage (:body (:body
-                             (cget "content/" id "?expand=body.storage"))))))
+                            (cget "content/" id "?expand=body.storage"))))))
 
 (defn children
   [id]

--- a/src/metadata_tool/sources/github.clj
+++ b/src/metadata_tool/sources/github.clj
@@ -16,18 +16,17 @@
 ;;
 
 (ns metadata-tool.sources.github
-  (:require
-    [clojure.string        :as s]
-    [clojure.java.io       :as io]
-    [clojure.tools.logging :as log]
-    [mount.core            :as mnt :refer [defstate]]
-    [lambdaisland.uri      :as uri]
-    [clj-jgit.porcelain    :as git]
-    [tentacles.core        :as tc]
-    [tentacles.repos       :as tr]
-    [tentacles.orgs        :as to]
-    [tentacles.users       :as tu]
-    [metadata-tool.config  :as cfg]))
+  (:require [clojure.string        :as s]
+            [clojure.java.io       :as io]
+            [clojure.tools.logging :as log]
+            [mount.core            :as mnt :refer [defstate]]
+            [lambdaisland.uri      :as uri]
+            [clj-jgit.porcelain    :as git]
+            [tentacles.core        :as tc]
+            [tentacles.repos       :as tr]
+            [tentacles.orgs        :as to]
+            [tentacles.users       :as tu]
+            [metadata-tool.config  :as cfg]))
 
 (def ^:private metadata-org-name  "finos")
 (def ^:private metadata-repo-name "metadata")
@@ -65,10 +64,10 @@
              (log/info "Using local metadata directory at" (:metadata-directory cfg/config))
              (:metadata-directory cfg/config))
            (let [result (str cfg/temp-directory
-                          (if (not (s/ends-with? cfg/temp-directory "/")) "/")
-                          "finos-metadata-" (java.util.UUID/randomUUID))
-                  _     (log/info "Cloning metadata repository to" result)
-                  repo  (git/with-credentials ^String username
+                             (if (not (s/ends-with? cfg/temp-directory "/")) "/")
+                             "finos-metadata-" (java.util.UUID/randomUUID))
+                 _      (log/info "Cloning metadata repository to" result)
+                 repo   (git/with-credentials ^String username
                           ^String password
                           (git/git-clone (str "https://github.com/" metadata-org-name "/" metadata-repo-name) result))]
              (when-not (s/blank? github-revision)
@@ -166,8 +165,8 @@
   (if repo-url
     (let [[org repo] (parse-github-url-path repo-url)]
       (if (and
-            (not (s/blank? org))
-            (not (s/blank? repo)))
+           (not (s/blank? org))
+           (not (s/blank? repo)))
         (let [result (call-gh (tr/specific-repo org repo opts))]
           (if-not (:private result)
             result))))))
@@ -181,8 +180,8 @@
   (if repo-url
     (let [[org repo] (parse-github-url-path repo-url)]
       (if (and
-            (not (s/blank? org))
-            (not (s/blank? repo)))
+           (not (s/blank? org))
+           (not (s/blank? repo)))
         (call-gh (tr/languages org repo opts))))))
 
 (def languages (memoize languages-fn))

--- a/src/metadata_tool/sources/github.clj
+++ b/src/metadata_tool/sources/github.clj
@@ -1,31 +1,33 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
 (ns metadata-tool.sources.github
-  (:require [clojure.string        :as s]
-            [clojure.java.io       :as io]
-            [clojure.tools.logging :as log]
-            [mount.core            :as mnt :refer [defstate]]
-            [lambdaisland.uri      :as uri]
-            [clj-jgit.porcelain    :as git]
-            [tentacles.core        :as tc]
-            [tentacles.repos       :as tr]
-            [tentacles.orgs        :as to]
-            [tentacles.users       :as tu]
-            [metadata-tool.config  :as cfg]))
+  (:require
+    [clojure.string        :as s]
+    [clojure.java.io       :as io]
+    [clojure.tools.logging :as log]
+    [mount.core            :as mnt :refer [defstate]]
+    [lambdaisland.uri      :as uri]
+    [clj-jgit.porcelain    :as git]
+    [tentacles.core        :as tc]
+    [tentacles.repos       :as tr]
+    [tentacles.orgs        :as to]
+    [tentacles.users       :as tu]
+    [metadata-tool.config  :as cfg]))
 
 (def ^:private metadata-org-name  "finos")
 (def ^:private metadata-repo-name "metadata")
@@ -40,44 +42,44 @@
   (io/delete-file file true))
 
 
-; ####TODO: ALLOW USE OF GITHUB TOKEN!!!
+;; ####TODO: ALLOW USE OF GITHUB TOKEN!!!
 
 (defstate username
-          :start (:username (:github cfg/config)))
+  :start (:username (:github cfg/config)))
 
 (defstate password
-          :start (:password (:github cfg/config)))
+  :start (:password (:github cfg/config)))
 
 (defstate auth
-          :start (str username ":" password))
+  :start (str username ":" password))
 
 (defstate opts
-          :start {:throw-exceptions true :all-pages true :per-page 100 :auth auth :user-agent (str metadata-org-name " metadata tool")})
+  :start {:throw-exceptions true :all-pages true :per-page 100 :auth auth :user-agent (str metadata-org-name " metadata tool")})
 
 (defstate github-revision
-          :start (:github-revision cfg/config))
+  :start (:github-revision cfg/config))
 
 (defstate metadata-directory
-          :start (if-not (s/blank? (:metadata-directory cfg/config))
-                   (do
-                     (log/info "Using local metadata directory at" (:metadata-directory cfg/config))
-                     (:metadata-directory cfg/config))
-                   (let [result (str cfg/temp-directory
-                                       (if (not (s/ends-with? cfg/temp-directory "/")) "/")
-                                       "finos-metadata-" (java.util.UUID/randomUUID))
-                         _      (log/info "Cloning metadata repository to" result)
-                         repo   (git/with-credentials ^String username
-                                                      ^String password
-                                                      (git/git-clone (str "https://github.com/" metadata-org-name "/" metadata-repo-name) result))]
-                     (when-not (s/blank? github-revision)
-                       (log/info "Checking out revision" github-revision)
-                       (git/git-checkout repo github-revision))
-                     (rm-rf (io/file (str result "/.git/")))    ; De-gitify the local clone so we can't accidentally mess with it
-                     result))
-          :stop  (if (not= metadata-directory (:metadata-directory cfg/config))
-                   (rm-rf (io/file metadata-directory))))
+  :start (if-not (s/blank? (:metadata-directory cfg/config))
+           (do
+             (log/info "Using local metadata directory at" (:metadata-directory cfg/config))
+             (:metadata-directory cfg/config))
+           (let [result (str cfg/temp-directory
+                          (if (not (s/ends-with? cfg/temp-directory "/")) "/")
+                          "finos-metadata-" (java.util.UUID/randomUUID))
+                  _     (log/info "Cloning metadata repository to" result)
+                  repo  (git/with-credentials ^String username
+                          ^String password
+                          (git/git-clone (str "https://github.com/" metadata-org-name "/" metadata-repo-name) result))]
+             (when-not (s/blank? github-revision)
+               (log/info "Checking out revision" github-revision)
+               (git/git-checkout repo github-revision))
+             (rm-rf (io/file (str result "/.git/")))    ; De-gitify the local clone so we can't accidentally mess with it
+             result))
+  :stop  (if (not= metadata-directory (:metadata-directory cfg/config))
+           (rm-rf (io/file metadata-directory))))
 
-; Note: functions that call GitHub APIs are memoized, so that when tools are "stacked" they benefit from cached GitHub API calls
+;; Note: functions that call GitHub APIs are memoized, so that when tools are "stacked" they benefit from cached GitHub API calls
 
 (defn- parse-github-url-path
   "Parses the path elements of a GitHub URL - useful for retrieving org name (first position) and repo name (optional second position)."
@@ -137,6 +139,7 @@
     (let [[org-name] (parse-github-url-path org-url)]
       (if-not (s/blank? org-name)
         (call-gh (to/specific-org org-name opts))))))
+
 (def org (memoize org-fn))
 
 (defn- repos-fn
@@ -147,6 +150,7 @@
     (let [[org-name] (parse-github-url-path org-url)]
       (if-not (s/blank? org-name)
         (remove #(some #{(:name %)} ignored-repo-names) (remove :private (call-gh (tr/org-repos org-name opts))))))))
+
 (def repos (memoize repos-fn))
 
 (defn repos-urls
@@ -161,11 +165,13 @@
   (log/debug "Requesting repository details for" repo-url)
   (if repo-url
     (let [[org repo] (parse-github-url-path repo-url)]
-      (if (and (not (s/blank? org))
-               (not (s/blank? repo)))
+      (if (and
+            (not (s/blank? org))
+            (not (s/blank? repo)))
         (let [result (call-gh (tr/specific-repo org repo opts))]
           (if-not (:private result)
             result))))))
+
 (def repo (memoize repo-fn))
 
 (defn- languages-fn
@@ -174,9 +180,11 @@
   (log/debug "Requesting repository languages for" repo-url)
   (if repo-url
     (let [[org repo] (parse-github-url-path repo-url)]
-      (if (and (not (s/blank? org))
-               (not (s/blank? repo)))
+      (if (and
+            (not (s/blank? org))
+            (not (s/blank? repo)))
         (call-gh (tr/languages org repo opts))))))
+
 (def languages (memoize languages-fn))
 
 (defn- user-fn
@@ -184,4 +192,5 @@
   [username]
   (if username
     (call-gh (tu/user username opts))))
+
 (def user (memoize user-fn))

--- a/src/metadata_tool/sources/joins.clj
+++ b/src/metadata_tool/sources/joins.clj
@@ -1,46 +1,47 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
-(ns metadata-tool.sources.joins
-  (:require [clojure.string                 :as s]
-            [clojure.tools.logging          :as log]
-            [clojure.set                    :as set]
-            [mount.core                     :as mnt :refer [defstate]]
-            [postal.core                    :as email]
-            [metadata-tool.config           :as cfg]
-            [metadata-tool.sources.github   :as gh]
-            [metadata-tool.sources.metadata :as md]
-            [metadata-tool.sources.bitergia :as bt]))
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 
+(ns metadata-tool.sources.joins
+  (:require
+    [clojure.string                 :as s]
+    [clojure.tools.logging          :as log]
+    [clojure.set                    :as set]
+    [mount.core                     :as mnt :refer [defstate]]
+    [postal.core                    :as email]
+    [metadata-tool.config           :as cfg]
+    [metadata-tool.sources.github   :as gh]
+    [metadata-tool.sources.metadata :as md]
+    [metadata-tool.sources.bitergia :as bt]))
 
 (defn activity-with-team
   "The given activity, augmented with the project team, as :project-leads and :committers."
   [activity]
   (if (and activity
-           (seq (:github-urls activity)))
+        (seq (:github-urls activity)))
     (assoc activity
-           :admins      (seq
-                          (sort-by :full-name
-                            (map md/person-metadata-by-github-login
-                                 (distinct
-                                   (remove nil?
-                                     (mapcat gh/admin-logins (:github-urls activity)))))))
-            :committers (seq
-                          (sort-by :full-name
-                            (map md/person-metadata-by-github-login
-                                 (distinct
-                                   (remove nil?
-                                     (mapcat gh/committer-logins (:github-urls activity))))))))))
+      :admins      (seq
+                     (sort-by :full-name
+                       (map md/person-metadata-by-github-login
+                         (distinct
+                           (remove nil?
+                             (mapcat gh/admin-logins (:github-urls activity)))))))
+      :committers (seq
+                    (sort-by :full-name
+                      (map md/person-metadata-by-github-login
+                        (distinct
+                          (remove nil?
+                            (mapcat gh/committer-logins (:github-urls activity))))))))))

--- a/src/metadata_tool/sources/joins.clj
+++ b/src/metadata_tool/sources/joins.clj
@@ -16,32 +16,31 @@
 ;;
 
 (ns metadata-tool.sources.joins
-  (:require
-    [clojure.string                 :as s]
-    [clojure.tools.logging          :as log]
-    [clojure.set                    :as set]
-    [mount.core                     :as mnt :refer [defstate]]
-    [postal.core                    :as email]
-    [metadata-tool.config           :as cfg]
-    [metadata-tool.sources.github   :as gh]
-    [metadata-tool.sources.metadata :as md]
-    [metadata-tool.sources.bitergia :as bt]))
+  (:require [clojure.string                 :as s]
+            [clojure.tools.logging          :as log]
+            [clojure.set                    :as set]
+            [mount.core                     :as mnt :refer [defstate]]
+            [postal.core                    :as email]
+            [metadata-tool.config           :as cfg]
+            [metadata-tool.sources.github   :as gh]
+            [metadata-tool.sources.metadata :as md]
+            [metadata-tool.sources.bitergia :as bt]))
 
 (defn activity-with-team
   "The given activity, augmented with the project team, as :project-leads and :committers."
   [activity]
   (if (and activity
-        (seq (:github-urls activity)))
+           (seq (:github-urls activity)))
     (assoc activity
-      :admins      (seq
-                     (sort-by :full-name
-                       (map md/person-metadata-by-github-login
-                         (distinct
-                           (remove nil?
-                             (mapcat gh/admin-logins (:github-urls activity)))))))
-      :committers (seq
-                    (sort-by :full-name
-                      (map md/person-metadata-by-github-login
-                        (distinct
-                          (remove nil?
-                            (mapcat gh/committer-logins (:github-urls activity))))))))))
+           :admins      (seq
+                         (sort-by :full-name
+                                  (map md/person-metadata-by-github-login
+                                       (distinct
+                                        (remove nil?
+                                                (mapcat gh/admin-logins (:github-urls activity)))))))
+           :committers (seq
+                        (sort-by :full-name
+                                 (map md/person-metadata-by-github-login
+                                      (distinct
+                                       (remove nil?
+                                               (mapcat gh/committer-logins (:github-urls activity))))))))))

--- a/src/metadata_tool/sources/metadata.clj
+++ b/src/metadata_tool/sources/metadata.clj
@@ -16,17 +16,16 @@
 ;;
 
 (ns metadata-tool.sources.metadata
-  (:require
-    [clojure.string                :as s]
-    [clojure.tools.logging         :as log]
-    [clojure.java.io               :as io]
-    [mount.core                    :as mnt :refer [defstate]]
-    [cheshire.core                 :as ch]
-    [clj-time.core                 :as tm]
-    [clj-time.format               :as tf]
-    [metadata-tool.config          :as cfg]
-    [metadata-tool.sources.github  :as gh]
-    [metadata-tool.sources.schemas :as sch]))
+  (:require [clojure.string                :as s]
+            [clojure.tools.logging         :as log]
+            [clojure.java.io               :as io]
+            [mount.core                    :as mnt :refer [defstate]]
+            [cheshire.core                 :as ch]
+            [clj-time.core                 :as tm]
+            [clj-time.format               :as tf]
+            [metadata-tool.config          :as cfg]
+            [metadata-tool.sources.github  :as gh]
+            [metadata-tool.sources.schemas :as sch]))
 
 (defstate ^:private organization-metadata-directory :start (str gh/metadata-directory "/organizations"))
 (defstate ^:private people-metadata-directory       :start (str gh/metadata-directory "/people"))
@@ -41,8 +40,8 @@
 (defn- list-metadata-files
   [filename]
   (doall
-    (sort-by #(.getCanonicalPath ^java.io.File %)
-      (filter #(= filename (.getName ^java.io.File %)) (file-seq (io/file gh/metadata-directory))))))
+   (sort-by #(.getCanonicalPath ^java.io.File %)
+            (filter #(= filename (.getName ^java.io.File %)) (file-seq (io/file gh/metadata-directory))))))
 
 (defstate ^:private organization-metadata-files :start (list-metadata-files organization-filename))
 (defstate ^:private person-metadata-files       :start (list-metadata-files person-filename))
@@ -51,20 +50,20 @@
 (defstate ^:private repository-metadata-files   :start (list-metadata-files repository-filename))
 
 (defstate ^:private metadata-files
-  :start { :organization organization-metadata-files
-           :person       person-metadata-files
-           :program      program-metadata-files
-           :activity     activity-metadata-files
-           :repository   repository-metadata-files })
+  :start {:organization organization-metadata-files
+          :person       person-metadata-files
+          :program      program-metadata-files
+          :activity     activity-metadata-files
+          :repository   repository-metadata-files })
 
 (defn- list-subdirs
   "Returns a sequence of the immediate subdirectories of dir, as java.io.File objects."
   [^java.io.File dir]
   (seq (.listFiles dir
-         (reify
-           java.io.FileFilter
-           (accept [this f]
-             (.isDirectory f))))))
+                   (reify
+                     java.io.FileFilter
+                     (accept [this f]
+                       (.isDirectory f))))))
 
 (defstate organizations :start (doall (sort (map #(.getName ^java.io.File %) (list-subdirs (io/file organization-metadata-directory))))))
 (defstate people        :start (doall (sort (map #(.getName ^java.io.File %) (list-subdirs (io/file people-metadata-directory))))))
@@ -74,12 +73,12 @@
   "Converts nasty JSON String keys (e.g. \"fullName\") to nice Clojure keys (e.g. :full-name)."
   [k]
   (keyword
-    (s/replace
-      (s/join "-"
-        (map s/lower-case
-          (s/split k #"(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])")))
-      "git-hub"
-      "github")))
+   (s/replace
+    (s/join "-"
+            (map s/lower-case
+                 (s/split k #"(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])")))
+    "git-hub"
+    "github")))
 
 (defn- read-metadata-file-fn
   [metadata-file]
@@ -94,10 +93,10 @@
   [schema-type ^java.io.File file]
   (log/debug "Validating" schema-type "metadata file" (.getCanonicalPath file))
   (try
-    (let [ json-string      (slurp file)
-           json             (ch/parse-string json-string clojurise-json-key)
-           metadata-version (:metadata-version json)
-           schema-id        [schema-type metadata-version]]
+    (let [json-string      (slurp file)
+          json             (ch/parse-string json-string clojurise-json-key)
+          metadata-version (:metadata-version json)
+          schema-id        [schema-type metadata-version]]
       (if metadata-version
         (sch/validate-json schema-id json-string)
         (throw (Exception. (str "No metadataVersion property.")))))
@@ -119,7 +118,7 @@
   (if organization-id
     (if-let [result (read-metadata-file (str organization-metadata-directory "/" organization-id "/" organization-filename))]
       (assoc result
-        :organization-id organization-id))))
+             :organization-id organization-id))))
 
 (defn organizations-metadata
   "A seq containing the metadata of all organizations, sorted by organization-name."
@@ -132,7 +131,7 @@
   (if person-id
     (if-let [person-metadata (read-metadata-file (str people-metadata-directory "/" person-id "/" person-filename))]
       (assoc person-metadata
-        :person-id person-id))))
+             :person-id person-id))))
 
 (defn person-metadata-with-organizations
   "Person metadata of the given person-id, with affiliations expanded to include full organization metadata."
@@ -140,7 +139,7 @@
   (if-let [person (person-metadata person-id)]
     (if-let [affiliations (:affiliations person)]
       (assoc person
-        :affiliations (seq (map #(assoc % :organization (organization-metadata (:organization-id %))) affiliations)))
+             :affiliations (seq (map #(assoc % :organization (organization-metadata (:organization-id %))) affiliations)))
       person)))
 
 (defn people-metadata
@@ -164,17 +163,17 @@
 (defn matches-person
   [person ghid name email]
   (or
-    (and
-      ;; (try
-      (not (s/blank? ghid))
-      ;; (catch Exception e (str ghid " " name " " email " - caught exception: " (.getMessage e))))
-      (some #{ghid} (:github-logins person)))
-    (and
-      (not (s/blank? name))
-      (= name (:full-name person)))
-    (and
-      (not (s/blank? email))
-      (some #{email} (:email-addresses person)))))
+   (and
+    ;; (try
+    (not (s/blank? ghid))
+    ;; (catch Exception e (str ghid " " name " " email " - caught exception: " (.getMessage e))))
+    (some #{ghid} (:github-logins person)))
+   (and
+    (not (s/blank? name))
+    (= name (:full-name person)))
+   (and
+    (not (s/blank? email))
+    (some #{email} (:email-addresses person)))))
 
 (defn person-metadata-by-fn
   [ghid name email]
@@ -193,8 +192,8 @@
   [email-address]
   (if email-address
     (first (filter #(some
-                      #{(s/lower-case email-address)}
-                      (lower-emails %)) (people-metadata)))))
+                     #{(s/lower-case email-address)}
+                     (lower-emails %)) (people-metadata)))))
 
 (def person-metadata-by-email-address
   "Person metadata of the given email address, or nil if there is none."
@@ -230,42 +229,40 @@
 (defn- expand-mailing-list-address
   [mailing-list-address]
   (if-not (s/blank? mailing-list-address)
-    {
-      :email-address   mailing-list-address
-      :web-archive-url (let [[list-name domain] (s/split mailing-list-address #"@")]
-                         (if (and (not (s/blank? list-name))
-                               (not (s/blank? domain))
-                               (or (= domain "finos.org")
-                                 (= domain "symphony.foundation")))
-                           (str "https://groups.google.com/a/" domain "/forum/#!forum/" list-name)))
-      }))
+    {:email-address   mailing-list-address
+     :web-archive-url (let [[list-name domain] (s/split mailing-list-address #"@")]
+                        (if (and (not (s/blank? list-name))
+                                 (not (s/blank? domain))
+                                 (or (= domain "finos.org")
+                                     (= domain "symphony.foundation")))
+                          (str "https://groups.google.com/a/" domain "/forum/#!forum/" list-name)))}))
 
 (defn- expand-confluence-space-key
   [confluence-space-key]
   (if-not (s/blank? confluence-space-key)
-    { :key confluence-space-key
-      :url (str "https://finosfoundation.atlassian.net/wiki/spaces/" confluence-space-key "/overview")}))
+    {:key confluence-space-key
+     :url (str "https://finosfoundation.atlassian.net/wiki/spaces/" confluence-space-key "/overview")}))
 
 (defn- program-activities-metadata
   "A seq containing the metadata of all activities in the given program."
   [program]
   (let [program-id (:program-id program)]
     (seq
-      (remove nil?
-        (map #(if-let [activity (read-metadata-file (str program-metadata-directory "/" program-id "/" % "/" activity-filename))]
-                (assoc activity
-                  :program-id              program-id
-                  :program-name            (:program-name program)
-                  :program-short-name      (:program-short-name program)
-                  :activity-id             %
-                  :tags                    (if-let [current-tags (:tags activity)]      ; Normalise tags to lower case, de-dupe and sort
-                                             (seq (sort (distinct (map s/lower-case (remove s/blank? current-tags))))))
-                  :lead-or-chair-person-id (:lead-or-chair activity)
-                  :lead-or-chair           (person-metadata (:lead-or-chair activity))
-                  :github-urls             (program-activity-github-urls program activity)
-                  :mailing-lists           (map expand-mailing-list-address (:mailing-list-addresses activity))
-                  :confluence-spaces       (map expand-confluence-space-key (:confluence-space-keys activity))))
-          (program-activities program-id))))))
+     (remove nil?
+             (map #(if-let [activity (read-metadata-file (str program-metadata-directory "/" program-id "/" % "/" activity-filename))]
+                     (assoc activity
+                            :program-id              program-id
+                            :program-name            (:program-name program)
+                            :program-short-name      (:program-short-name program)
+                            :activity-id             %
+                            :tags                    (if-let [current-tags (:tags activity)]      ; Normalise tags to lower case, de-dupe and sort
+                                                       (seq (sort (distinct (map s/lower-case (remove s/blank? current-tags))))))
+                            :lead-or-chair-person-id (:lead-or-chair activity)
+                            :lead-or-chair           (person-metadata (:lead-or-chair activity))
+                            :github-urls             (program-activity-github-urls program activity)
+                            :mailing-lists           (map expand-mailing-list-address (:mailing-list-addresses activity))
+                            :confluence-spaces       (map expand-confluence-space-key (:confluence-space-keys activity))))
+                  (program-activities program-id))))))
 
 (defn- program-metadata-fn
   "Program metadata of the given program-id, or nil if there is none."
@@ -273,13 +270,13 @@
   (if-let [program (read-metadata-file (str program-metadata-directory "/" program-id "/" program-filename))]
     (let [program (assoc program :program-id program-id)]   ; Note: this assoc has to happen first, since (program-activities-metadata) depends on it.
       (assoc program
-        :github-url               (if (:github-org program) (str "https://github.com/" (:github-org program)))
-        :pmc-github-urls          (pmc-github-urls program)
-        :activities               (program-activities-metadata program)
-        :pmc-mailing-list         (expand-mailing-list-address (:pmc-mailing-list-address         program))
-        :pmc-private-mailing-list (expand-mailing-list-address (:pmc-private-mailing-list-address program))
-        :program-mailing-list     (expand-mailing-list-address (:program-mailing-list-address     program))
-        :confluence-space         (expand-confluence-space-key (:confluence-space-key             program))))))
+             :github-url               (if (:github-org program) (str "https://github.com/" (:github-org program)))
+             :pmc-github-urls          (pmc-github-urls program)
+             :activities               (program-activities-metadata program)
+             :pmc-mailing-list         (expand-mailing-list-address (:pmc-mailing-list-address         program))
+             :pmc-private-mailing-list (expand-mailing-list-address (:pmc-private-mailing-list-address program))
+             :program-mailing-list     (expand-mailing-list-address (:program-mailing-list-address     program))
+             :confluence-space         (expand-confluence-space-key (:confluence-space-key             program))))))
 (def program-metadata (memoize program-metadata-fn))
 
 (defn programs-metadata
@@ -322,11 +319,11 @@
   "True if the given 'date range' map (with a :start-date and/or :end-date key) is current i.e. spans today."
   [m]
   (if m
-    (let [today       (tf/unparse (tf/formatters :date) (tm/now))
-           start-date (:start-date m)
-           end-date   (:end-date   m)]
+    (let [today      (tf/unparse (tf/formatters :date) (tm/now))
+          start-date (:start-date m)
+          end-date   (:end-date   m)]
       (and (or (nil? start-date) (neg? (compare start-date today)))
-        (or (nil? end-date)   (neg? (compare today end-date)))))))
+           (or (nil? end-date)   (neg? (compare today end-date)))))))
 
 (defn current-approved-contributors
   "A seq of person metadata for the *currently* approved contributors for the given organization-id, or nil if there are none."
@@ -356,23 +353,23 @@
   [program type]
   (let [program-id (:id program)]
     (map #(:activity-name %)
-      (remove #(= "ARCHIVED" (:state %))
-        (filter #(= type (:type %))
-          (:activities program))))))
+         (remove #(= "ARCHIVED" (:state %))
+                 (filter #(= type (:type %))
+                         (:activities program))))))
 
 (defn pmc-lead
   [program]
-  (let [pmc-lead       (:pmc-lead program)
-         lead-enriched (person-metadata pmc-lead)
-         full-name     (:full-name lead-enriched)
-         org-name      (:org-name (assoc-org-name lead-enriched))]
+  (let [pmc-lead      (:pmc-lead program)
+        lead-enriched (person-metadata pmc-lead)
+        full-name     (:full-name lead-enriched)
+        org-name      (:org-name (assoc-org-name lead-enriched))]
     (str full-name org-name)))
 
 (defn pmc-list
   [program]
-  (let [pmc-list         (:pmc program)
-         people-enriched (map #(person-metadata %) pmc-list)
-         orgs-enriched   (map #(assoc-org-name %) people-enriched)]
+  (let [pmc-list        (:pmc program)
+        people-enriched (map #(person-metadata %) pmc-list)
+        orgs-enriched   (map #(assoc-org-name %) people-enriched)]
     (map #(str (:full-name %) (:org-name %)) orgs-enriched)))
 
 (defn has-icla?
@@ -383,16 +380,16 @@
   [person-id]
   (if-let [current-affiliations-with-cclas (seq (filter :has-ccla (current-affiliations person-id)))]
     (let [current-approved-contributors (map :person-id
-                                          (mapcat #(current-approved-contributors (:organization-id %))
-                                            current-affiliations-with-cclas))]
+                                             (mapcat #(current-approved-contributors (:organization-id %))
+                                                     current-affiliations-with-cclas))]
       (or (empty? current-approved-contributors)
-        (boolean (some #{person-id} current-approved-contributors))))
+          (boolean (some #{person-id} current-approved-contributors))))
     false))
 
 (defn has-cla?
   [person-id]
   (or (has-icla? person-id)
-    (has-ccla? person-id)))
+      (has-ccla? person-id)))
 
 (defn people-with-clas
   "A seq of person metadata for all people who currently have CLAs with the Foundation."

--- a/src/metadata_tool/sources/metadata.clj
+++ b/src/metadata_tool/sources/metadata.clj
@@ -1,30 +1,32 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
 (ns metadata-tool.sources.metadata
-  (:require [clojure.string                :as s]
-            [clojure.tools.logging         :as log]
-            [clojure.java.io               :as io]
-            [mount.core                    :as mnt :refer [defstate]]
-            [cheshire.core                 :as ch]
-            [clj-time.core                 :as tm]
-            [clj-time.format               :as tf]
-            [metadata-tool.config          :as cfg]
-            [metadata-tool.sources.github  :as gh]
-            [metadata-tool.sources.schemas :as sch]))
+  (:require
+    [clojure.string                :as s]
+    [clojure.tools.logging         :as log]
+    [clojure.java.io               :as io]
+    [mount.core                    :as mnt :refer [defstate]]
+    [cheshire.core                 :as ch]
+    [clj-time.core                 :as tm]
+    [clj-time.format               :as tf]
+    [metadata-tool.config          :as cfg]
+    [metadata-tool.sources.github  :as gh]
+    [metadata-tool.sources.schemas :as sch]))
 
 (defstate ^:private organization-metadata-directory :start (str gh/metadata-directory "/organizations"))
 (defstate ^:private people-metadata-directory       :start (str gh/metadata-directory "/people"))
@@ -40,7 +42,7 @@
   [filename]
   (doall
     (sort-by #(.getCanonicalPath ^java.io.File %)
-             (filter #(= filename (.getName ^java.io.File %)) (file-seq (io/file gh/metadata-directory))))))
+      (filter #(= filename (.getName ^java.io.File %)) (file-seq (io/file gh/metadata-directory))))))
 
 (defstate ^:private organization-metadata-files :start (list-metadata-files organization-filename))
 (defstate ^:private person-metadata-files       :start (list-metadata-files person-filename))
@@ -59,10 +61,10 @@
   "Returns a sequence of the immediate subdirectories of dir, as java.io.File objects."
   [^java.io.File dir]
   (seq (.listFiles dir
-                   (reify
-                     java.io.FileFilter
-                     (accept [this f]
-                       (.isDirectory f))))))
+         (reify
+           java.io.FileFilter
+           (accept [this f]
+             (.isDirectory f))))))
 
 (defstate organizations :start (doall (sort (map #(.getName ^java.io.File %) (list-subdirs (io/file organization-metadata-directory))))))
 (defstate people        :start (doall (sort (map #(.getName ^java.io.File %) (list-subdirs (io/file people-metadata-directory))))))
@@ -74,8 +76,8 @@
   (keyword
     (s/replace
       (s/join "-"
-              (map s/lower-case
-                   (s/split k #"(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])")))
+        (map s/lower-case
+          (s/split k #"(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])")))
       "git-hub"
       "github")))
 
@@ -84,6 +86,7 @@
   (let [the-file (io/file metadata-file)]
     (when (.exists the-file)
       (ch/parse-string (slurp the-file) clojurise-json-key))))
+
 (def ^:private read-metadata-file (memoize read-metadata-file-fn))
 
 (defn- validate-metadata-file
@@ -91,10 +94,10 @@
   [schema-type ^java.io.File file]
   (log/debug "Validating" schema-type "metadata file" (.getCanonicalPath file))
   (try
-    (let [json-string      (slurp file)
-          json             (ch/parse-string json-string clojurise-json-key)
-          metadata-version (:metadata-version json)
-          schema-id        [schema-type metadata-version]]
+    (let [ json-string      (slurp file)
+           json             (ch/parse-string json-string clojurise-json-key)
+           metadata-version (:metadata-version json)
+           schema-id        [schema-type metadata-version]]
       (if metadata-version
         (sch/validate-json schema-id json-string)
         (throw (Exception. (str "No metadataVersion property.")))))
@@ -116,7 +119,7 @@
   (if organization-id
     (if-let [result (read-metadata-file (str organization-metadata-directory "/" organization-id "/" organization-filename))]
       (assoc result
-             :organization-id organization-id))))
+        :organization-id organization-id))))
 
 (defn organizations-metadata
   "A seq containing the metadata of all organizations, sorted by organization-name."
@@ -129,7 +132,7 @@
   (if person-id
     (if-let [person-metadata (read-metadata-file (str people-metadata-directory "/" person-id "/" person-filename))]
       (assoc person-metadata
-             :person-id person-id))))
+        :person-id person-id))))
 
 (defn person-metadata-with-organizations
   "Person metadata of the given person-id, with affiliations expanded to include full organization metadata."
@@ -137,7 +140,7 @@
   (if-let [person (person-metadata person-id)]
     (if-let [affiliations (:affiliations person)]
       (assoc person
-             :affiliations (seq (map #(assoc % :organization (organization-metadata (:organization-id %))) affiliations)))
+        :affiliations (seq (map #(assoc % :organization (organization-metadata (:organization-id %))) affiliations)))
       person)))
 
 (defn people-metadata
@@ -161,44 +164,47 @@
 (defn matches-person
   [person ghid name email]
   (or
-      (and
-        ; (try
-        (not (s/blank? ghid))
-          ; (catch Exception e (str ghid " " name " " email " - caught exception: " (.getMessage e))))
-        (some #{ghid} (:github-logins person)))
-      (and
-        (not (s/blank? name))
-        (= name (:full-name person)))
-      (and
-        (not (s/blank? email))
-        (some #{email} (:email-addresses person)))))
-  
+    (and
+      ;; (try
+      (not (s/blank? ghid))
+      ;; (catch Exception e (str ghid " " name " " email " - caught exception: " (.getMessage e))))
+      (some #{ghid} (:github-logins person)))
+    (and
+      (not (s/blank? name))
+      (= name (:full-name person)))
+    (and
+      (not (s/blank? email))
+      (some #{email} (:email-addresses person)))))
+
 (defn person-metadata-by-fn
   [ghid name email]
   (if (or ghid name email)
     (first (filter #(matches-person % ghid name email) (people-metadata)))))
+
 (def person-metadata-by
   "Person metadata of either a given GitHub login, name or email address; returns nil if there is none."
   (memoize person-metadata-by-fn))
-  
+
 (defn lower-emails
   [item]
   (map #(s/lower-case %) (:email-addresses item)))
 
 (defn person-metadata-by-email-address-fn
-    [email-address]
-    (if email-address
-      (first (filter #(some 
-                        #{(s/lower-case email-address)}
-                        (lower-emails %)) (people-metadata)))))
+  [email-address]
+  (if email-address
+    (first (filter #(some
+                      #{(s/lower-case email-address)}
+                      (lower-emails %)) (people-metadata)))))
+
 (def person-metadata-by-email-address
   "Person metadata of the given email address, or nil if there is none."
   (memoize person-metadata-by-email-address-fn))
-  
+
 (defn person-metadata-by-fullname-fn
   [full-name]
   (if full-name
     (first (filter #(= full-name (:full-name %)) (people-metadata)))))
+
 (def person-metadata-by-fullname
   "Person metadata of the given fullname, or nil if there is none."
   (memoize person-metadata-by-email-address-fn))
@@ -219,8 +225,8 @@
 (defn- pmc-github-urls
   [program]
   (github-urls program (:pmc-repos program)))
-  ; (github-urls program (map #(s/lower-case %) (:pmc-repos program))))
-  
+;; (github-urls program (map #(s/lower-case %) (:pmc-repos program))))
+
 (defn- expand-mailing-list-address
   [mailing-list-address]
   (if-not (s/blank? mailing-list-address)
@@ -228,19 +234,17 @@
       :email-address   mailing-list-address
       :web-archive-url (let [[list-name domain] (s/split mailing-list-address #"@")]
                          (if (and (not (s/blank? list-name))
-                                  (not (s/blank? domain))
-                                  (or (= domain "finos.org")
-                                      (= domain "symphony.foundation")))
+                               (not (s/blank? domain))
+                               (or (= domain "finos.org")
+                                 (= domain "symphony.foundation")))
                            (str "https://groups.google.com/a/" domain "/forum/#!forum/" list-name)))
-    }))
+      }))
 
 (defn- expand-confluence-space-key
   [confluence-space-key]
   (if-not (s/blank? confluence-space-key)
-    {
-      :key confluence-space-key
-      :url (str "https://finosfoundation.atlassian.net/wiki/spaces/" confluence-space-key "/overview")
-    }))
+    { :key confluence-space-key
+      :url (str "https://finosfoundation.atlassian.net/wiki/spaces/" confluence-space-key "/overview")}))
 
 (defn- program-activities-metadata
   "A seq containing the metadata of all activities in the given program."
@@ -250,18 +254,18 @@
       (remove nil?
         (map #(if-let [activity (read-metadata-file (str program-metadata-directory "/" program-id "/" % "/" activity-filename))]
                 (assoc activity
-                       :program-id              program-id
-                       :program-name            (:program-name program)
-                       :program-short-name      (:program-short-name program)
-                       :activity-id             %
-                       :tags                    (if-let [current-tags (:tags activity)]      ; Normalise tags to lower case, de-dupe and sort
-                                                  (seq (sort (distinct (map s/lower-case (remove s/blank? current-tags))))))
-                       :lead-or-chair-person-id (:lead-or-chair activity)
-                       :lead-or-chair           (person-metadata (:lead-or-chair activity))
-                       :github-urls             (program-activity-github-urls program activity)
-                       :mailing-lists           (map expand-mailing-list-address (:mailing-list-addresses activity))
-                       :confluence-spaces       (map expand-confluence-space-key (:confluence-space-keys activity))))
-             (program-activities program-id))))))
+                  :program-id              program-id
+                  :program-name            (:program-name program)
+                  :program-short-name      (:program-short-name program)
+                  :activity-id             %
+                  :tags                    (if-let [current-tags (:tags activity)]      ; Normalise tags to lower case, de-dupe and sort
+                                             (seq (sort (distinct (map s/lower-case (remove s/blank? current-tags))))))
+                  :lead-or-chair-person-id (:lead-or-chair activity)
+                  :lead-or-chair           (person-metadata (:lead-or-chair activity))
+                  :github-urls             (program-activity-github-urls program activity)
+                  :mailing-lists           (map expand-mailing-list-address (:mailing-list-addresses activity))
+                  :confluence-spaces       (map expand-confluence-space-key (:confluence-space-keys activity))))
+          (program-activities program-id))))))
 
 (defn- program-metadata-fn
   "Program metadata of the given program-id, or nil if there is none."
@@ -269,13 +273,13 @@
   (if-let [program (read-metadata-file (str program-metadata-directory "/" program-id "/" program-filename))]
     (let [program (assoc program :program-id program-id)]   ; Note: this assoc has to happen first, since (program-activities-metadata) depends on it.
       (assoc program
-             :github-url               (if (:github-org program) (str "https://github.com/" (:github-org program)))
-             :pmc-github-urls          (pmc-github-urls program)
-             :activities               (program-activities-metadata program)
-             :pmc-mailing-list         (expand-mailing-list-address (:pmc-mailing-list-address         program))
-             :pmc-private-mailing-list (expand-mailing-list-address (:pmc-private-mailing-list-address program))
-             :program-mailing-list     (expand-mailing-list-address (:program-mailing-list-address     program))
-             :confluence-space         (expand-confluence-space-key (:confluence-space-key             program))))))
+        :github-url               (if (:github-org program) (str "https://github.com/" (:github-org program)))
+        :pmc-github-urls          (pmc-github-urls program)
+        :activities               (program-activities-metadata program)
+        :pmc-mailing-list         (expand-mailing-list-address (:pmc-mailing-list-address         program))
+        :pmc-private-mailing-list (expand-mailing-list-address (:pmc-private-mailing-list-address program))
+        :program-mailing-list     (expand-mailing-list-address (:program-mailing-list-address     program))
+        :confluence-space         (expand-confluence-space-key (:confluence-space-key             program))))))
 (def program-metadata (memoize program-metadata-fn))
 
 (defn programs-metadata
@@ -299,6 +303,7 @@
     (if-let [result (first (filter #(= activity-name (:activity-name %)) (activities-metadata)))]
       result
       (log/warn "Could not find metadata for" activity-name))))
+
 (def activity-metadata-by-name
   "The metadata for a specific activity, identified by name."
   (memoize activity-metadata-by-name-fn))
@@ -317,11 +322,11 @@
   "True if the given 'date range' map (with a :start-date and/or :end-date key) is current i.e. spans today."
   [m]
   (if m
-    (let [today      (tf/unparse (tf/formatters :date) (tm/now))
-          start-date (:start-date m)
-          end-date   (:end-date   m)]
+    (let [today       (tf/unparse (tf/formatters :date) (tm/now))
+           start-date (:start-date m)
+           end-date   (:end-date   m)]
       (and (or (nil? start-date) (neg? (compare start-date today)))
-           (or (nil? end-date)   (neg? (compare today end-date)))))))
+        (or (nil? end-date)   (neg? (compare today end-date)))))))
 
 (defn current-approved-contributors
   "A seq of person metadata for the *currently* approved contributors for the given organization-id, or nil if there are none."
@@ -350,26 +355,26 @@
 (defn activities
   [program type]
   (let [program-id (:id program)]
-  (map #(:activity-name %)
-        (remove #(= "ARCHIVED" (:state %))
-          (filter #(= type (:type %))
-            (:activities program))))))
+    (map #(:activity-name %)
+      (remove #(= "ARCHIVED" (:state %))
+        (filter #(= type (:type %))
+          (:activities program))))))
 
 (defn pmc-lead
   [program]
   (let [pmc-lead       (:pmc-lead program)
-        lead-enriched  (person-metadata pmc-lead)
-        full-name      (:full-name lead-enriched)
-        org-name       (:org-name (assoc-org-name lead-enriched))]
+         lead-enriched (person-metadata pmc-lead)
+         full-name     (:full-name lead-enriched)
+         org-name      (:org-name (assoc-org-name lead-enriched))]
     (str full-name org-name)))
 
 (defn pmc-list
   [program]
-  (let [pmc-list        (:pmc program)
-        people-enriched (map #(person-metadata %) pmc-list)
-        orgs-enriched   (map #(assoc-org-name %) people-enriched)]
+  (let [pmc-list         (:pmc program)
+         people-enriched (map #(person-metadata %) pmc-list)
+         orgs-enriched   (map #(assoc-org-name %) people-enriched)]
     (map #(str (:full-name %) (:org-name %)) orgs-enriched)))
-            
+
 (defn has-icla?
   [person-id]
   (boolean (:has-icla (person-metadata person-id))))
@@ -378,16 +383,16 @@
   [person-id]
   (if-let [current-affiliations-with-cclas (seq (filter :has-ccla (current-affiliations person-id)))]
     (let [current-approved-contributors (map :person-id
-                                             (mapcat #(current-approved-contributors (:organization-id %))
-                                                     current-affiliations-with-cclas))]
+                                          (mapcat #(current-approved-contributors (:organization-id %))
+                                            current-affiliations-with-cclas))]
       (or (empty? current-approved-contributors)
-          (boolean (some #{person-id} current-approved-contributors))))
+        (boolean (some #{person-id} current-approved-contributors))))
     false))
 
 (defn has-cla?
   [person-id]
   (or (has-icla? person-id)
-      (has-ccla? person-id)))
+    (has-ccla? person-id)))
 
 (defn people-with-clas
   "A seq of person metadata for all people who currently have CLAs with the Foundation."

--- a/src/metadata_tool/sources/schemas.clj
+++ b/src/metadata_tool/sources/schemas.clj
@@ -1,27 +1,29 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
 (ns metadata-tool.sources.schemas
-  (:require [clojure.string               :as s]
-            [clojure.tools.logging        :as log]
-            [clojure.java.io              :as io]
-            [mount.core                   :as mnt :refer [defstate]]
-            [scjsv.core                   :as jsv]
-            [metadata-tool.config         :as cfg]
-            [metadata-tool.sources.github :as gh]))
+  (:require
+    [clojure.string               :as s]
+    [clojure.tools.logging        :as log]
+    [clojure.java.io              :as io]
+    [mount.core                   :as mnt :refer [defstate]]
+    [scjsv.core                   :as jsv]
+    [metadata-tool.config         :as cfg]
+    [metadata-tool.sources.github :as gh]))
 
 (defstate schema-directories
   "The available types of schema, and the location of their version-specific schema definition files within the metadata repository."
@@ -29,15 +31,14 @@
            :person       (str gh/metadata-directory "/jsonschema/person-metadata")
            :program      (str gh/metadata-directory "/jsonschema/program-metadata")
            :activity     (str gh/metadata-directory "/jsonschema/activity-metadata")
-           :repository   (str gh/metadata-directory "/jsonschema/repository-metadata")
-         })
+           :repository   (str gh/metadata-directory "/jsonschema/repository-metadata")})
 
 (defstate schema-ids
   "Set of all available schema types and versions."
   :start (let [schema-types (keys schema-directories)]
            (set (for [schema-type schema-types
-                      version     (map #(.getName ^java.io.File %)
-                                       (.listFiles (io/file (get schema-directories schema-type))))]
+                       version    (map #(.getName ^java.io.File %)
+                                    (.listFiles (io/file (get schema-directories schema-type))))]
                   [schema-type version]))))
 
 (defn- load-schema

--- a/src/metadata_tool/sources/schemas.clj
+++ b/src/metadata_tool/sources/schemas.clj
@@ -16,29 +16,28 @@
 ;;
 
 (ns metadata-tool.sources.schemas
-  (:require
-    [clojure.string               :as s]
-    [clojure.tools.logging        :as log]
-    [clojure.java.io              :as io]
-    [mount.core                   :as mnt :refer [defstate]]
-    [scjsv.core                   :as jsv]
-    [metadata-tool.config         :as cfg]
-    [metadata-tool.sources.github :as gh]))
+  (:require [clojure.string               :as s]
+            [clojure.tools.logging        :as log]
+            [clojure.java.io              :as io]
+            [mount.core                   :as mnt :refer [defstate]]
+            [scjsv.core                   :as jsv]
+            [metadata-tool.config         :as cfg]
+            [metadata-tool.sources.github :as gh]))
 
 (defstate schema-directories
   "The available types of schema, and the location of their version-specific schema definition files within the metadata repository."
-  :start { :organization (str gh/metadata-directory "/jsonschema/organization-metadata")
-           :person       (str gh/metadata-directory "/jsonschema/person-metadata")
-           :program      (str gh/metadata-directory "/jsonschema/program-metadata")
-           :activity     (str gh/metadata-directory "/jsonschema/activity-metadata")
-           :repository   (str gh/metadata-directory "/jsonschema/repository-metadata")})
+  :start {:organization (str gh/metadata-directory "/jsonschema/organization-metadata")
+          :person       (str gh/metadata-directory "/jsonschema/person-metadata")
+          :program      (str gh/metadata-directory "/jsonschema/program-metadata")
+          :activity     (str gh/metadata-directory "/jsonschema/activity-metadata")
+          :repository   (str gh/metadata-directory "/jsonschema/repository-metadata")})
 
 (defstate schema-ids
   "Set of all available schema types and versions."
   :start (let [schema-types (keys schema-directories)]
            (set (for [schema-type schema-types
-                       version    (map #(.getName ^java.io.File %)
-                                    (.listFiles (io/file (get schema-directories schema-type))))]
+                      version     (map #(.getName ^java.io.File %)
+                                       (.listFiles (io/file (get schema-directories schema-type))))]
                   [schema-type version]))))
 
 (defn- load-schema

--- a/src/metadata_tool/template.clj
+++ b/src/metadata_tool/template.clj
@@ -16,20 +16,19 @@
 ;;
 
 (ns metadata-tool.template
-  (:require
-    [clojure.string        :as s]
-    [clojure.tools.logging :as log]
-    [mount.core            :as mnt :refer [defstate]]
-    [freemarker-clj.core   :as ftl]))
+  (:require [clojure.string        :as s]
+            [clojure.tools.logging :as log]
+            [mount.core            :as mnt :refer [defstate]]
+            [freemarker-clj.core   :as ftl]))
 
 (def ^:private template-path "/templates/")
 
 (defstate freemarker-config
-          :start (doto ^freemarker.template.Configuration (ftl/gen-config)
-                   (.setClassLoaderForTemplateLoading (.getContextClassLoader (Thread/currentThread))
-                                                      template-path)
-                   (.setDefaultEncoding "UTF-8")
-                   (.setLocale (java.util.Locale/US))))
+  :start (doto ^freemarker.template.Configuration (ftl/gen-config)
+           (.setClassLoaderForTemplateLoading (.getContextClassLoader (Thread/currentThread))
+                                              template-path)
+           (.setDefaultEncoding "UTF-8")
+           (.setLocale (java.util.Locale/US))))
 
 (defn render
   "Renders the data (as a map) using the named template file (which must exist in the templates folder), returning the rendered result as a String."

--- a/src/metadata_tool/template.clj
+++ b/src/metadata_tool/template.clj
@@ -1,25 +1,26 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 
 (ns metadata-tool.template
-  (:require [clojure.string        :as s]
-            [clojure.tools.logging :as log]
-            [mount.core            :as mnt :refer [defstate]]
-            [freemarker-clj.core   :as ftl]))
+  (:require
+    [clojure.string        :as s]
+    [clojure.tools.logging :as log]
+    [mount.core            :as mnt :refer [defstate]]
+    [freemarker-clj.core   :as ftl]))
 
 (def ^:private template-path "/templates/")
 

--- a/src/metadata_tool/tools/checkers.clj
+++ b/src/metadata_tool/tools/checkers.clj
@@ -16,19 +16,18 @@
 ;;
 
 (ns metadata-tool.tools.checkers
-  (:require
-    [clojure.string                 :as s]
-    [clojure.set                    :as set]
-    [clojure.pprint                 :as pp]
-    [clojure.tools.logging          :as log]
-    [clojure.java.io                :as io]
-    [mount.core                     :as mnt :refer [defstate]]
-    [metadata-tool.exit-code        :as ec]
-    [metadata-tool.config           :as cfg]
-    [metadata-tool.sources.github   :as gh]
-    [metadata-tool.sources.bitergia :as bi]
-    [metadata-tool.sources.schemas  :as sch]
-    [metadata-tool.sources.metadata :as md]))
+  (:require [clojure.string                 :as s]
+            [clojure.set                    :as set]
+            [clojure.pprint                 :as pp]
+            [clojure.tools.logging          :as log]
+            [clojure.java.io                :as io]
+            [mount.core                     :as mnt :refer [defstate]]
+            [metadata-tool.exit-code        :as ec]
+            [metadata-tool.config           :as cfg]
+            [metadata-tool.sources.github   :as gh]
+            [metadata-tool.sources.bitergia :as bi]
+            [metadata-tool.sources.schemas  :as sch]
+            [metadata-tool.sources.metadata :as md]))
 
 
 ;; Utility fns
@@ -41,7 +40,7 @@
   [state]
   (if-not (s/blank? state)
     (str (s/upper-case (first state))
-      (s/join (rest (s/lower-case state))))))
+         (s/join (rest (s/lower-case state))))))
 
 (defn- activity-to-string
   [activity]
@@ -57,36 +56,36 @@
 (defn- check-current-affiliations
   []
   (doall
-    (map #(if (empty? (md/current-affiliations %))
-            (println "ℹ️ Person" % "has no current affiliations."))
-      md/people)))
+   (map #(if (empty? (md/current-affiliations %))
+           (println "ℹ️ Person" % "has no current affiliations."))
+        md/people)))
 
 (defn- check-duplicate-email-addresses
   []
   (let [email-frequencies (frequencies (mapcat :email-addresses (md/people-metadata)))
-         duplicate-emails (filter #(> (get email-frequencies %) 1) (keys email-frequencies))]
+        duplicate-emails  (filter #(> (get email-frequencies %) 1) (keys email-frequencies))]
     (if (> (count duplicate-emails) 0) (ec/set-error))
     (doall (map #(println "❌ Email" % "appears more than once.") duplicate-emails))))
 
 (defn- check-duplicate-github-logins
   []
   (let [github-login-frequencies (frequencies (mapcat :github-logins (md/people-metadata)))
-         duplicate-github-logins (filter #(> (get github-login-frequencies %) 1) (keys github-login-frequencies))]
+        duplicate-github-logins  (filter #(> (get github-login-frequencies %) 1) (keys github-login-frequencies))]
     (if (> (count duplicate-github-logins) 0) (ec/set-error))
     (doall (map #(println "❌ GitHub login" % "appears more than once.") duplicate-github-logins))))
 
 (defn- check-affiliation-references
   []
-  (let [ affiliation-org-ids          (seq (distinct (mapcat #(map :organization-id (:affiliations %)) (md/people-metadata))))
-         invalid-affiliations-org-ids (filter #(nil? (md/organization-metadata %)) affiliation-org-ids)]
+  (let [affiliation-org-ids          (seq (distinct (mapcat #(map :organization-id (:affiliations %)) (md/people-metadata))))
+        invalid-affiliations-org-ids (filter #(nil? (md/organization-metadata %)) affiliation-org-ids)]
     (if (> (count invalid-affiliations-org-ids) 0) (ec/set-error))
     (doall (map #(println "❌ Organization id" % "(used in an affiliation) doesn't have metadata.") invalid-affiliations-org-ids))))
 
 (defn- check-approved-contributor-references
   []
-  (let [ approved-contributors                   (remove nil? (mapcat :approved-contributors (md/organizations-metadata)))
-         approved-contributor-person-ids         (seq (distinct (map :person-id approved-contributors)))
-         invalid-approved-contributor-person-ids (filter #(nil? (md/person-metadata %)) approved-contributor-person-ids)]
+  (let [approved-contributors                   (remove nil? (mapcat :approved-contributors (md/organizations-metadata)))
+        approved-contributor-person-ids         (seq (distinct (map :person-id approved-contributors)))
+        invalid-approved-contributor-person-ids (filter #(nil? (md/person-metadata %)) approved-contributor-person-ids)]
     (if (> (count invalid-approved-contributor-person-ids) 0) (ec/set-error))
     (doall (map #(println "❌ Person id" % "(used in an approved contributor) doesn't have metadata.") invalid-approved-contributor-person-ids))))
 
@@ -97,8 +96,8 @@
 
 (defn- check-pmc-lead-references
   []
-  (let [ pmc-lead-person-ids         (seq (distinct (map :pmc-lead (md/programs-metadata))))
-         invalid-pmc-lead-person-ids (filter #(nil? (md/person-metadata %)) (remove nil? pmc-lead-person-ids))]
+  (let [pmc-lead-person-ids         (seq (distinct (map :pmc-lead (md/programs-metadata))))
+        invalid-pmc-lead-person-ids (filter #(nil? (md/person-metadata %)) (remove nil? pmc-lead-person-ids))]
     (if (> (count invalid-pmc-lead-person-ids) 0) (ec/set-error))
     (doall (map #(println "❌ Person id" % "(a PMC lead) doesn't have metadata.") invalid-pmc-lead-person-ids))))
 
@@ -108,12 +107,12 @@
     (doall (map #(if (= "ARCHIVED" (:state %))
                    (println "ℹ️ Archived" (type-to-string (:type %)) (activity-to-string %) "doesn't have a" (str (if (= "PROJECT" (:type %)) "lead" "chair") "."))
                    (println "⚠️" (state-to-string (:state %)) (type-to-string (:type %)) (activity-to-string %) "doesn't have a" (str (if (= "PROJECT" (:type %)) "lead" "chair") ".")))
-             activities-with-missing-lead-or-chair))))
+                activities-with-missing-lead-or-chair))))
 
 (defn- check-lead-or-chair-references
   []
-  (let [ lead-or-chair-person-ids                    (seq (distinct (remove nil? (map :lead-or-chair-person-id (md/activities-metadata)))))
-         invalid-lead-or-chair-person-ids-person-ids (filter #(nil? (md/person-metadata %)) lead-or-chair-person-ids)]
+  (let [lead-or-chair-person-ids                    (seq (distinct (remove nil? (map :lead-or-chair-person-id (md/activities-metadata)))))
+        invalid-lead-or-chair-person-ids-person-ids (filter #(nil? (md/person-metadata %)) lead-or-chair-person-ids)]
     (if (> (count invalid-lead-or-chair-person-ids-person-ids) 0) (ec/set-error))
     (doall (map #(println "❌ Person id" % "(a Project Lead or Working Group chair) doesn't have metadata.") invalid-lead-or-chair-person-ids-person-ids))))
 
@@ -144,8 +143,8 @@
 
 (defn- check-states-and-dates
   []
-  (let [ released-projects-without-release-dates    (filter #(and (= (:state %) "RELEASED") (nil? (:release-date %))) (md/projects-metadata))
-         archived-activities-without-archived-dates (filter #(and (= (:state %) "ARCHIVED") (nil? (:archive-date %))) (md/activities-metadata))]
+  (let [released-projects-without-release-dates    (filter #(and (= (:state %) "RELEASED") (nil? (:release-date %))) (md/projects-metadata))
+        archived-activities-without-archived-dates (filter #(and (= (:state %) "ARCHIVED") (nil? (:archive-date %))) (md/activities-metadata))]
     (if (> (count released-projects-without-release-dates) 0)
       (ec/set-error))
     (doall (map #(println "❌ Project" (activity-to-string %) "is released, but has no release date") released-projects-without-release-dates))
@@ -155,8 +154,8 @@
 
 (defn- check-github-coords
   []
-  (let [ programs-without-github-org                     (filter #(nil? (:github-org %)) (md/programs-metadata))
-         programs-without-github-org-with-activity-repos (filter #(seq (mapcat :github-repos (:activities %))) programs-without-github-org)]
+  (let [programs-without-github-org                     (filter #(nil? (:github-org %)) (md/programs-metadata))
+        programs-without-github-org-with-activity-repos (filter #(seq (mapcat :github-repos (:activities %))) programs-without-github-org)]
     (doall (map #(println "⚠️ Program" (str (:program-id %)) "does not have a GitHub org.") programs-without-github-org))
     (if (> (count programs-without-github-org-with-activity-repos) 0)
       (ec/set-error))
@@ -164,17 +163,17 @@
 
 (defn- check-mailing-list-addresses
   []
-  (let [ programs-metadata                (md/programs-metadata)
-         activities-metadata              (mapcat :activities programs-metadata)
-         unknown-program-email-addresses  (remove #(or (s/ends-with? % "@finos.org")
-                                                     (s/ends-with? % "@symphony.foundation"))
-                                            (remove s/blank? (mapcat #(vec [(:pmc-mailing-list-address         %)
-                                                                             (:pmc-private-mailing-list-address %)
-                                                                             (:program-mailing-list-address     %)])
-                                                               programs-metadata)))
-         unknown-activity-email-addresses (remove #(or (s/ends-with? % "@finos.org")
-                                                     (s/ends-with? % "@symphony.foundation"))
-                                            (remove s/blank? (mapcat :mailing-list-addresses activities-metadata)))]
+  (let [programs-metadata                (md/programs-metadata)
+        activities-metadata              (mapcat :activities programs-metadata)
+        unknown-program-email-addresses  (remove #(or (s/ends-with? % "@finos.org")
+                                                      (s/ends-with? % "@symphony.foundation"))
+                                                 (remove s/blank? (mapcat #(vec [(:pmc-mailing-list-address         %)
+                                                                                 (:pmc-private-mailing-list-address %)
+                                                                                 (:program-mailing-list-address     %)])
+                                                                          programs-metadata)))
+        unknown-activity-email-addresses (remove #(or (s/ends-with? % "@finos.org")
+                                                      (s/ends-with? % "@symphony.foundation"))
+                                                 (remove s/blank? (mapcat :mailing-list-addresses activities-metadata)))]
     (if (> (count unknown-program-email-addresses) 0) (ec/set-error))
     (doall (map #(println "❌ Mailing list address" % "(a program-level mailing list) does not appear to be Foundation-managed.") unknown-program-email-addresses))
     (if (> (count unknown-activity-email-addresses) 0) (ec/set-error))
@@ -208,22 +207,22 @@
   []
   (let [activities-with-github-urls (sort-by activity-to-string (remove #(empty? (:github-urls %)) (md/activities-metadata)))]
     (doall
-      (map #(doall
-              (map (fn [github-url]
-                     (if (empty? (gh/admin-logins github-url))
-                       (if (= "ARCHIVED" (:state %))
-                         (println "ℹ️ GitHub Repository" github-url "in archived" (type-to-string (:type %)) (activity-to-string %) "has no admins, or they haven't accepted their invitations yet.")
-                         (println "⚠️ GitHub Repository" github-url "in" (type-to-string (:type %)) (activity-to-string %) "has no admins, or they haven't accepted their invitations yet."))))
-                (:github-urls %)))
-        activities-with-github-urls))))
+     (map #(doall
+            (map (fn [github-url]
+                   (if (empty? (gh/admin-logins github-url))
+                     (if (= "ARCHIVED" (:state %))
+                       (println "ℹ️ GitHub Repository" github-url "in archived" (type-to-string (:type %)) (activity-to-string %) "has no admins, or they haven't accepted their invitations yet.")
+                       (println "⚠️ GitHub Repository" github-url "in" (type-to-string (:type %)) (activity-to-string %) "has no admins, or they haven't accepted their invitations yet."))))
+                 (:github-urls %)))
+          activities-with-github-urls))))
 
 (defn- check-metadata-for-collaborators
   []
-  (let [ github-urls   (mapcat :github-urls (md/activities-metadata))
-         github-logins (sort (distinct (mapcat gh/collaborator-logins github-urls)))]
+  (let [github-urls   (mapcat :github-urls (md/activities-metadata))
+        github-logins (sort (distinct (mapcat gh/collaborator-logins github-urls)))]
     (doall (map #(if-not (md/person-metadata-by-github-login %)
                    (println "⚠️ GitHub login" % "doesn't have any metadata."))
-             github-logins))))
+                github-logins))))
 
 (defn- check-github-orgs
   []
@@ -234,30 +233,30 @@
 
 (defn- check-github-repos
   []
-  (let [ github-repo-urls       (set (map s/lower-case (remove s/blank? (mapcat #(gh/repos-urls (:github-url %)) (md/programs-metadata)))))
-         metadata-repo-urls     (set (map s/lower-case (remove s/blank? (mapcat :github-urls (md/activities-metadata)))))
-         plus-pmc-repo-urls     (set (flatten (concat metadata-repo-urls (mapcat :pmc-github-urls (md/programs-metadata)))))
-         repos-without-metadata (sort (set/difference github-repo-urls plus-pmc-repo-urls))
-         metadatas-without-repo (sort (set/difference plus-pmc-repo-urls github-repo-urls))]
+  (let [github-repo-urls       (set (map s/lower-case (remove s/blank? (mapcat #(gh/repos-urls (:github-url %)) (md/programs-metadata)))))
+        metadata-repo-urls     (set (map s/lower-case (remove s/blank? (mapcat :github-urls (md/activities-metadata)))))
+        plus-pmc-repo-urls     (set (flatten (concat metadata-repo-urls (mapcat :pmc-github-urls (md/programs-metadata)))))
+        repos-without-metadata (sort (set/difference github-repo-urls plus-pmc-repo-urls))
+        metadatas-without-repo (sort (set/difference plus-pmc-repo-urls github-repo-urls))]
     (doall (map #(println "⚠️ GitHub repo" % "has no metadata.") repos-without-metadata))
     (doall (map #(println "⚠️ GitHub repo" % "has metadata, but does not exist in GitHub.") metadatas-without-repo))))
 
 (defn- check-github-logins
   []
-  (let [ all-github-logins     (distinct (remove s/blank? (mapcat :github-logins (md/people-metadata))))
-         invalid-github-logins (sort (filter #(nil? (gh/user %)) all-github-logins))]
+  (let [all-github-logins     (distinct (remove s/blank? (mapcat :github-logins (md/people-metadata))))
+        invalid-github-logins (sort (filter #(nil? (gh/user %)) all-github-logins))]
     (doall (map #(println "ℹ️ GitHub username" % "is invalid (note: may be preserved for historical purposes).") invalid-github-logins))))
 
 (defn- check-bitergia-projects
   []
-  (let [ activity-names                   (set (map :activity-name
-                                                 (remove #(and (nil? (seq (:github-repos           %)))
-                                                            (nil? (seq (:mailing-list-addresses %)))
-                                                            (nil? (seq (:confluence-space-keys  %))))
-                                                   (md/activities-metadata))))
-         activities-missing-from-bitergia (sort (set/difference activity-names (bi/all-projects)))]
+  (let [activity-names                   (set (map :activity-name
+                                                   (remove #(and (nil? (seq (:github-repos           %)))
+                                                                 (nil? (seq (:mailing-list-addresses %)))
+                                                                 (nil? (seq (:confluence-space-keys  %))))
+                                                           (md/activities-metadata))))
+        activities-missing-from-bitergia (sort (set/difference activity-names (bi/all-projects)))]
     (doall (map #(println "ℹ️ Activity" (activity-to-string (md/activity-metadata-by-name %)) "is missing from the Bitergia indexes (this is normal if there's been no activity in GitHub, Confluence, and the mailing lists yet).")
-             activities-missing-from-bitergia))))
+                activities-missing-from-bitergia))))
 
 (defn check-remote
   "Performs checks that require API calls out to GitHub, JIRA, Bitergia, etc. (which may be rate limited)."

--- a/src/metadata_tool/tools/generators.clj
+++ b/src/metadata_tool/tools/generators.clj
@@ -16,78 +16,76 @@
 ;;
 
 (ns metadata-tool.tools.generators
-  (:require
-    [clojure.string                   :as s]
-    [clojure.set                      :as set]
-    [clojure.pprint                   :as pp]
-    [clojure.tools.logging            :as log]
-    [clojure.java.io                  :as io]
-    [clojure.data.csv                 :as csv]
-    [mount.core                       :as mnt :refer [defstate]]
-    [cheshire.core                    :as ch]
-    [metadata-tool.tools.parsers      :as psrs]
-    [metadata-tool.config             :as cfg]
-    [metadata-tool.template           :as tem]
-    [metadata-tool.sources.confluence :as cfl]
-    [metadata-tool.sources.github     :as gh]
-    [metadata-tool.sources.bitergia   :as bi]
-    [metadata-tool.sources.schemas    :as sch]
-    [metadata-tool.sources.metadata   :as md]))
+  (:require [clojure.string                   :as s]
+            [clojure.set                      :as set]
+            [clojure.pprint                   :as pp]
+            [clojure.tools.logging            :as log]
+            [clojure.java.io                  :as io]
+            [clojure.data.csv                 :as csv]
+            [mount.core                       :as mnt :refer [defstate]]
+            [cheshire.core                    :as ch]
+            [metadata-tool.tools.parsers      :as psrs]
+            [metadata-tool.config             :as cfg]
+            [metadata-tool.template           :as tem]
+            [metadata-tool.sources.confluence :as cfl]
+            [metadata-tool.sources.github     :as gh]
+            [metadata-tool.sources.bitergia   :as bi]
+            [metadata-tool.sources.schemas    :as sch]
+            [metadata-tool.sources.metadata   :as md]))
 
 (defn gen-clabot-whitelist
   []
   (println (tem/render "clabot-whitelist.ftl"
-             { :github-ids (sort (mapcat :github-logins (md/people-with-clas))) })))
+                       {:github-ids (sort (mapcat :github-logins (md/people-with-clas))) })))
 
 (defn gen-bitergia-affiliation-data
   []
   (println (tem/render "bitergia-affiliations.ftl"
-                       { :people (md/people-metadata-with-organizations) })))
+                       {:people (md/people-metadata-with-organizations) })))
 
 (defn gen-bitergia-organization-data
   []
   (println (tem/render "bitergia-organizations.ftl"
-                       { :organizations (md/organizations-metadata) })))
+                       {:organizations (md/organizations-metadata) })))
 
 (defn gen-bitergia-project-data
   []
   (println (tem/render "bitergia-projects.ftl"
-                       { :programs   (md/programs-metadata)
-                         :activities (md/activities-metadata) })))
-
+                       {:programs   (md/programs-metadata)
+                        :activities (md/activities-metadata) })))
 
 (defn- build-github-repo-data
   [repo-url]
   (if-let [repo (gh/repo repo-url)]
     (let [ collaborators (gh/collaborators repo-url)
-           languages     (gh/languages     repo-url)]
-      { :name          (or (:name        repo) "")
-        :description   (or (:description repo) "")
-        :url           repo-url
-        :heat          (+ (* (count collaborators)           4)
+          languages      (gh/languages     repo-url)]
+      {:name          (or (:name        repo) "")
+       :description   (or (:description repo) "")
+       :url           repo-url
+       :heat          (+ (* (count collaborators)           4)
                          (* (or (:forks_count      repo) 0) 5)
                          (* (or (:stargazers_count repo) 0) 1)
                          (* (or (:watchers_count   repo) 0) 1))
-        :watchers      (or (:watchers_count    repo) 0)
-        :size          (or (:size              repo) 0)
-        :collaborators (count collaborators)
-        :stars         (or (:stargazers_count  repo) 0)
-        :forks         (or (:forks_count       repo) 0)
-        :open-issues   (or (:open_issues_count repo) 0)
-        :languages     languages})
+       :watchers      (or (:watchers_count    repo) 0)
+       :size          (or (:size              repo) 0)
+       :collaborators (count collaborators)
+       :stars         (or (:stargazers_count  repo) 0)
+       :forks         (or (:forks_count       repo) 0)
+       :open-issues   (or (:open_issues_count repo) 0)
+       :languages     languages})
     (log/warn "Unable to retrieve GitHub repository metadata for" repo-url)))
 
 (defn- accumulate-github-stats
   [github-repos]
   (if-not (empty? github-repos)
-    { :heat          (apply +                      (map :heat          github-repos))
-      :watchers      (apply +                      (map :watchers      github-repos)) ; ####TODO: Fix double counting
-      :size          (apply +                      (map :size          github-repos))
-      :collaborators (apply +                      (map :collaborators github-repos)) ; ####TODO: Fix double counting
-      :stars         (apply +                      (map :stars         github-repos)) ; ####TODO: Fix double counting
-      :forks         (apply +                      (map :forks         github-repos))
-      :open-issues   (apply +                      (map :open-issues   github-repos))
-      :languages     (apply (partial merge-with +) (map :languages     github-repos))}))
+    {:heat          (apply +                      (map :heat          github-repos))
+     :watchers      (apply +                      (map :watchers      github-repos)) ; ####TODO: Fix double counting
+     :size          (apply +                      (map :size          github-repos))
+     :collaborators (apply +                      (map :collaborators github-repos)) ; ####TODO: Fix double counting
+     :stars         (apply +                      (map :stars         github-repos)) ; ####TODO: Fix double counting
+     :forks         (apply +                      (map :forks         github-repos))
+     :open-issues   (apply +                      (map :open-issues   github-repos))
+     :languages     (apply (partial merge-with +) (map :languages     github-repos))}))
 
 (defn gen-catalogue-data
   []
@@ -102,36 +100,35 @@
                                    :cumulative-github-stats (accumulate-github-stats github-repos))))]
     (println (tem/render "catalogue.ftl"
                          { :activities activities-data
-                           :all-tags   (md/all-activity-tags) }))))
+                          :all-tags    (md/all-activity-tags) }))))
 
 (defn- gen-activity-roster
   [program-name activity-metadata]
   (let [activity-name (:activity-name activity-metadata)]
     (if-let [page-url (:confluence-page activity-metadata)]
       (psrs/meetings-rosters
-        program-name
-        activity-name
-        (:type activity-metadata)
-        page-url))))
+       program-name
+       activity-name
+       (:type activity-metadata)
+       page-url))))
 
 (defn- gen-program-roster
   [program-metadata]
-  (let [program-name (:program-short-name program-metadata)] [
-    (println (str "Generating meeting attendance for program " program-name))
-    (if-let [pmc-confluence-page (:pmc-confluence-page program-metadata)]
-      (psrs/meetings-rosters
+  (let [program-name (:program-short-name program-metadata)]
+    [(println (str "Generating meeting attendance for program " program-name))
+     (if-let [pmc-confluence-page (:pmc-confluence-page program-metadata)]
+       (psrs/meetings-rosters
         program-name
         (str program-name " PMC")
         "PMC"
         pmc-confluence-page))
-    (map #(gen-activity-roster program-name %) (:activities program-metadata))]))
+     (map #(gen-activity-roster program-name %) (:activities program-metadata))]))
 
 (defn gen-meeting-roster-data
   []
-  (let [programs (md/programs-metadata)
-         roster-data
-         (remove nil? (flatten
-                        (map
-                          #(gen-program-roster %)
-                          programs)))]
+  (let [programs    (md/programs-metadata)
+        roster-data (remove nil? (flatten
+                                  (map
+                                   #(gen-program-roster %)
+                                   programs)))]
     (psrs/roster-to-csv roster-data)))

--- a/src/metadata_tool/tools/listers.clj
+++ b/src/metadata_tool/tools/listers.clj
@@ -1,35 +1,36 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
 (ns metadata-tool.tools.listers
-  (:require [clojure.string                 :as s]
-            [clojure.set                    :as set]
-            [clojure.pprint                 :as pp]
-            [clojure.tools.logging          :as log]
-            [clojure.java.io                :as io]
-            [mount.core                     :as mnt :refer [defstate]]
-            [cheshire.core                  :as ch]
-            [clj-time.core                  :as tm]
-            [clj-time.format                :as tf]
-            [metadata-tool.config           :as cfg]
-            [metadata-tool.sources.github   :as gh]
-            [metadata-tool.sources.bitergia :as bi]
-            [metadata-tool.sources.schemas  :as sch]
-            [metadata-tool.sources.metadata :as md]
-            ))
+  (:require
+    [clojure.string                 :as s]
+    [clojure.set                    :as set]
+    [clojure.pprint                 :as pp]
+    [clojure.tools.logging          :as log]
+    [clojure.java.io                :as io]
+    [mount.core                     :as mnt :refer [defstate]]
+    [cheshire.core                  :as ch]
+    [clj-time.core                  :as tm]
+    [clj-time.format                :as tf]
+    [metadata-tool.config           :as cfg]
+    [metadata-tool.sources.github   :as gh]
+    [metadata-tool.sources.bitergia :as bi]
+    [metadata-tool.sources.schemas  :as sch]
+    [metadata-tool.sources.metadata :as md]))
 
 
 (defn list-schemas
@@ -39,5 +40,3 @@
 (defn list-people-with-clas
   []
   (doall (map #(pp/pprint (:full-name %)) (sort-by :full-name (md/people-with-clas)))))
-
-

--- a/src/metadata_tool/tools/listers.clj
+++ b/src/metadata_tool/tools/listers.clj
@@ -16,21 +16,20 @@
 ;;
 
 (ns metadata-tool.tools.listers
-  (:require
-    [clojure.string                 :as s]
-    [clojure.set                    :as set]
-    [clojure.pprint                 :as pp]
-    [clojure.tools.logging          :as log]
-    [clojure.java.io                :as io]
-    [mount.core                     :as mnt :refer [defstate]]
-    [cheshire.core                  :as ch]
-    [clj-time.core                  :as tm]
-    [clj-time.format                :as tf]
-    [metadata-tool.config           :as cfg]
-    [metadata-tool.sources.github   :as gh]
-    [metadata-tool.sources.bitergia :as bi]
-    [metadata-tool.sources.schemas  :as sch]
-    [metadata-tool.sources.metadata :as md]))
+  (:require [clojure.string                 :as s]
+            [clojure.set                    :as set]
+            [clojure.pprint                 :as pp]
+            [clojure.tools.logging          :as log]
+            [clojure.java.io                :as io]
+            [mount.core                     :as mnt :refer [defstate]]
+            [cheshire.core                  :as ch]
+            [clj-time.core                  :as tm]
+            [clj-time.format                :as tf]
+            [metadata-tool.config           :as cfg]
+            [metadata-tool.sources.github   :as gh]
+            [metadata-tool.sources.bitergia :as bi]
+            [metadata-tool.sources.schemas  :as sch]
+            [metadata-tool.sources.metadata :as md]))
 
 
 (defn list-schemas

--- a/src/metadata_tool/tools/parsers.clj
+++ b/src/metadata_tool/tools/parsers.clj
@@ -1,204 +1,202 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
 (ns metadata-tool.tools.parsers
-    (:require [clojure.string                       :as s]
-              [hickory.core                         :as html]
-              [clojure.java.io                      :as io]
-              [clojure.pprint                       :as pp]
-              [hickory.select                       :as sel]
-              [metadata-tool.sources.confluence     :as cfl]
-              [metadata-tool.config                 :as cfg]
-              [metadata-tool.sources.metadata       :as md]
-              ))
+  (:require
+    [clojure.string                       :as s]
+    [hickory.core                         :as html]
+    [clojure.java.io                      :as io]
+    [clojure.pprint                       :as pp]
+    [hickory.select                       :as sel]
+    [metadata-tool.sources.confluence     :as cfl]
+    [metadata-tool.config                 :as cfg]
+    [metadata-tool.sources.metadata       :as md]))
 
 (def not-nil? (complement nil?))
 
 (defn parse-string
-    [string]
-    (if (s/blank? string)
-        string
-        (s/replace
-            (s/trim string)
-            "\u00A0"
-            "")))
+  [string]
+  (if (s/blank? string)
+    string
+    (s/replace
+      (s/trim string)
+      "\u00A0"
+      "")))
 
 (defn parse-name
-    [string to-remove]
-    (if (s/blank? string)
-        nil
-        (if (empty? to-remove)
+  [string to-remove]
+  (if (s/blank? string)
+    nil
+    (if (empty? to-remove)
+      string
+      (if-let [acronym (get (:acronyms (:confluence cfg/config)) string)]
+        acronym
+        (parse-name
+          (s/replace
             string
-            (if-let [acronym (get (:acronyms (:confluence cfg/config)) string)]
-                acronym
-                    (parse-name
-                        (s/replace
-                            string
-                            (first to-remove)
-                            "")
-                        (rest to-remove))))))
+            (first to-remove)
+            "")
+          (rest to-remove))))))
 
 (defn parse-date
-    [title]
-    (let [title-parsed (s/replace title "." "-")
-          indexes 
-            (filter #(>= % 0) 
-                (remove nil? (map #(s/index-of title-parsed %)
-                (:years (:confluence cfg/config)))))]
-        (if (not-empty indexes)
-            (first (s/split
-                (subs
-                    title-parsed
-                    (first indexes))
-                #" "))
-        title)))
+  [title]
+  (let [title-parsed (s/replace title "." "-")
+         indexes
+         (filter #(>= % 0)
+           (remove nil? (map #(s/index-of title-parsed %)
+                          (:years (:confluence cfg/config)))))]
+    (if (not-empty indexes)
+      (first (s/split
+               (subs
+                 title-parsed
+                 (first indexes))
+               #" "))
+      title)))
 
 (defn id-and-title
-    [payload]
-    {:id (:id payload) :title (:title payload)})
+  [payload]
+  { :id    (:id payload)
+    :title (:title payload)})
 
 (defn skip-page
-    [page-title]
-    (> (count 
-        (filter #(s/includes? 
-            (s/upper-case page-title) 
-            (s/upper-case %)) (:skip-pages (:confluence cfg/config)))) 0))
+  [page-title]
+  (> (count
+       (filter #(s/includes?
+                  (s/upper-case page-title)
+                  (s/upper-case %)) (:skip-pages (:confluence cfg/config)))) 0))
 
 (defn table-html
-    [html]
-    (let [first-table (str (first (s/split html #"</table>")) "</table>")
-            after-h1-title (s/split first-table #"<h1>Attendees</h1>")
-            after-h2-title (s/split first-table #"<h2>Attendees</h2>")]
-        (let [payload
-                (if 
-                    (> (count after-h1-title) 1)
+  [html]
+  (let [ first-table    (str (first (s/split html #"</table>")) "</table>")
+         after-h1-title (s/split first-table #"<h1>Attendees</h1>")
+         after-h2-title (s/split first-table #"<h2>Attendees</h2>")]
+    (let [payload (if (> (count after-h1-title) 1)
                     (second after-h1-title)
-                    (if 
-                        (> (count after-h2-title) 1)
-                        (second after-h2-title)))]
-            (if (and
-                    payload
-                    (s/starts-with? (s/trim payload) "<table"))
-                (s/trim payload)))))
+                    (if (> (count after-h2-title) 1)
+                      (second after-h2-title)))]
+      (if (and
+            payload
+            (s/starts-with? (s/trim payload) "<table"))
+        (s/trim payload)))))
 
 (defn resolve-user
-    [element]
-    (let [user-element (sel/select (sel/descendant (sel/tag (keyword "ri:user"))) element)
-          select-leaf (sel/not (sel/has-child sel/any))]
-        (if (not-empty user-element)
-            (let [user-key (get (:attrs (first user-element)) (keyword "ri:userkey"))
-                  body (:body (cfl/cget (str "user?expand=email&key=" user-key)))]
-                [(:email body) (:displayName body)])
-            (if-let [name (:content (first (sel/select select-leaf element)))]
-                [nil (parse-string (apply str name))]
-                nil))))
+  [element]
+  (let [ user-element (sel/select (sel/descendant (sel/tag (keyword "ri:user"))) element)
+         select-leaf  (sel/not (sel/has-child sel/any))]
+    (if (not-empty user-element)
+      (let [ user-key (get (:attrs (first user-element)) (keyword "ri:userkey"))
+             body     (:body (cfl/cget (str "user?expand=email&key=" user-key)))]
+        [(:email body) (:displayName body)])
+      (if-let [name (:content (first (sel/select select-leaf element)))]
+        [nil (parse-string (apply str name))]
+        nil))))
 
 (defn row-to-user
-    [row program activity type meeting-date]
-    (let [items      (sel/select (sel/child (sel/tag :tr) (sel/tag :td)) row)
-          id         (resolve-user (first items))
-          email      (first id)
-          name       (parse-string (parse-name (second id) (:remove-from-names (:confluence cfg/config))))
-          orgItem    (second items)
-          select-leaf   (sel/not (sel/has-child sel/any))
-          org        (or 
-                        (apply str (:content (first (sel/select sel/last-child orgItem))))
-                        (apply str (:content (first (sel/select select-leaf orgItem)))))
-          ghid          (if (> (count items) 2) (:content (first (sel/select select-leaf (nth items 2)))) nil)
-          user-by-md    (md/person-metadata-by-fn nil name email)]
-        ; (if-not (s/blank? name)
-        ;     (let []
-        ;         (println (str 
-        ;             "'" name "' '" org "' '" ghid 
-        ;             "(" (Character/codePointAt name (dec (count name))) ")"))))
-        (if-not (or
-            (some #(= name %) (:ignore-names (:confluence cfg/config)))
-            (and 
+  [row program activity type meeting-date]
+  (let [ items       (sel/select (sel/child (sel/tag :tr) (sel/tag :td)) row)
+         id          (resolve-user (first items))
+         email       (first id)
+         name        (parse-string (parse-name (second id) (:remove-from-names (:confluence cfg/config))))
+         orgItem     (second items)
+         select-leaf (sel/not (sel/has-child sel/any))
+         org         (or
+                       (apply str (:content (first (sel/select sel/last-child orgItem))))
+                       (apply str (:content (first (sel/select select-leaf orgItem)))))
+         ghid        (if (> (count items) 2) (:content (first (sel/select select-leaf (nth items 2)))) nil)
+         user-by-md  (md/person-metadata-by-fn nil name email)]
+    ;; (if-not (s/blank? name)
+    ;;     (let []
+    ;;         (println (str
+    ;;             "'" name "' '" org "' '" ghid
+    ;;             "(" (Character/codePointAt name (dec (count name))) ")"))))
+    (if-not (or
+              (some #(= name %) (:ignore-names (:confluence cfg/config)))
+              (and
                 (s/blank? name)
                 (s/blank? org)
                 (s/blank? ghid))) {
-                :email (or 
-                    (first (:email-addresses user-by-md))
-                    (first id))
-                :name (or
-                    (:full-name user-by-md)
-                    name)
-                :org (or
-                    (:organization-name (first (md/current-affiliations (:person-id user-by-md))))
-                    org)
-                :ghid (or
-                    (first (:github-logins user-by-md)))
-                    ; TODO - cannot rely on GitHub data as third column;
-                    ; right now it contains all sorts of data
-                    ; ghid)
-                :program program
-                :activity activity
-                :type type
-                :meeting-date meeting-date}
-            nil)))
+                                    :email        (or
+                                                    (first (:email-addresses user-by-md))
+                                                    (first id))
+                                    :name         (or
+                                                    (:full-name user-by-md)
+                                                    name)
+                                    :org          (or
+                                                    (:organization-name (first (md/current-affiliations (:person-id user-by-md))))
+                                                    org)
+                                    :ghid         (or
+                                                    (first (:github-logins user-by-md)))
+                                    ;; TODO - cannot rely on GitHub data as third column;
+                                    ;; right now it contains all sorts of data
+                                    ;; ghid)
+                                    :program      program
+                                    :activity     activity
+                                    :type         type
+                                    :meeting-date meeting-date}
+      nil)))
 
 (defn meeting-roster
-    [table-html page-title program activity type]
-    (let [meeting-date (parse-date page-title)
-          selector    (sel/tag :tr)]
-        (let [table (html/as-hickory (html/parse table-html))
-              rows  (sel/select selector table)]
-            (map 
-                #(row-to-user % program activity type meeting-date)
-                rows))))
+  [table-html page-title program activity type]
+  (let [meeting-date (parse-date page-title)
+         selector    (sel/tag :tr)]
+    (let [table (html/as-hickory (html/parse table-html))
+           rows (sel/select selector table)]
+      (map
+        #(row-to-user % program activity type meeting-date)
+        rows))))
 
 (defn parse-page
-    [page-data program activity type]
-    (let [content (cfl/content (:id page-data))
-          title (:title page-data)]
-        (if-not (skip-page title)
-            (let [table-html (table-html (cfl/content (:id page-data)))]
-                (if-not (empty? table-html)
-                    (meeting-roster 
-                        table-html
-                        title
-                        program
-                        activity
-                        type)))
-            [])))
+  [page-data program activity type]
+  (let [content (cfl/content (:id page-data))
+         title  (:title page-data)]
+    (if-not (skip-page title)
+      (let [table-html (table-html (cfl/content (:id page-data)))]
+        (if-not (empty? table-html)
+          (meeting-roster
+            table-html
+            title
+            program
+            activity
+            type)))
+      [])))
 
 (defn ids-and-titles
-    [id]
-    (let [children (map #(id-and-title %) (cfl/children id))]
-        (flatten
-            (concat 
-                children
-                (map #(ids-and-titles (:id %)) children)))))
+  [id]
+  (let [children (map #(id-and-title %) (cfl/children id))]
+    (flatten
+      (concat
+        children
+        (map #(ids-and-titles (:id %)) children)))))
 
 (defn meetings-rosters
-    [program activity type url]
-    (println (str "Generating meeting attendance for activity " activity))
-    (let [page-id   (cfl/page-id url)
-          sub-pages (ids-and-titles page-id)]
-        (remove nil? (flatten (map 
-            #(parse-page % program activity type)
-            sub-pages)))))
+  [program activity type url]
+  (println (str "Generating meeting attendance for activity " activity))
+  (let [page-id    (cfl/page-id url)
+         sub-pages (ids-and-titles page-id)]
+    (remove nil? (flatten (map
+                            #(parse-page % program activity type)
+                            sub-pages)))))
 
 (defn roster-to-csv
-    [roster-data]
-    (with-open [writer (io/writer "finos-meetings.csv")]
-        (.write writer "email, name, org, github ID, cm_program, cm_title, cm_type, date\n")
-        (doall 
-        (map 
-            #(.write writer (str (s/join ", " (vals %)) "\n")) 
-            roster-data))
-        (.flush writer)))
-              
+  [roster-data]
+  (with-open [writer (io/writer "finos-meetings.csv")]
+    (.write writer "email, name, org, github ID, cm_program, cm_title, cm_type, date\n")
+    (doall
+      (map
+        #(.write writer (str (s/join ", " (vals %)) "\n"))
+        roster-data))
+    (.flush writer)))

--- a/src/metadata_tool/tools/parsers.clj
+++ b/src/metadata_tool/tools/parsers.clj
@@ -16,15 +16,14 @@
 ;;
 
 (ns metadata-tool.tools.parsers
-  (:require
-    [clojure.string                       :as s]
-    [hickory.core                         :as html]
-    [clojure.java.io                      :as io]
-    [clojure.pprint                       :as pp]
-    [hickory.select                       :as sel]
-    [metadata-tool.sources.confluence     :as cfl]
-    [metadata-tool.config                 :as cfg]
-    [metadata-tool.sources.metadata       :as md]))
+  (:require [clojure.string                       :as s]
+            [hickory.core                         :as html]
+            [clojure.java.io                      :as io]
+            [clojure.pprint                       :as pp]
+            [hickory.select                       :as sel]
+            [metadata-tool.sources.confluence     :as cfl]
+            [metadata-tool.config                 :as cfg]
+            [metadata-tool.sources.metadata       :as md]))
 
 (def not-nil? (complement nil?))
 
@@ -33,9 +32,9 @@
   (if (s/blank? string)
     string
     (s/replace
-      (s/trim string)
-      "\u00A0"
-      "")))
+     (s/trim string)
+     "\u00A0"
+     "")))
 
 (defn parse-name
   [string to-remove]
@@ -46,60 +45,60 @@
       (if-let [acronym (get (:acronyms (:confluence cfg/config)) string)]
         acronym
         (parse-name
-          (s/replace
-            string
-            (first to-remove)
-            "")
-          (rest to-remove))))))
+         (s/replace
+          string
+          (first to-remove)
+          "")
+         (rest to-remove))))))
 
 (defn parse-date
   [title]
   (let [title-parsed (s/replace title "." "-")
-         indexes
-         (filter #(>= % 0)
-           (remove nil? (map #(s/index-of title-parsed %)
-                          (:years (:confluence cfg/config)))))]
+        indexes
+        (filter #(>= % 0)
+                (remove nil? (map #(s/index-of title-parsed %)
+                                  (:years (:confluence cfg/config)))))]
     (if (not-empty indexes)
       (first (s/split
-               (subs
-                 title-parsed
-                 (first indexes))
-               #" "))
+              (subs
+               title-parsed
+               (first indexes))
+              #" "))
       title)))
 
 (defn id-and-title
   [payload]
-  { :id    (:id payload)
-    :title (:title payload)})
+  { :id   (:id payload)
+   :title (:title payload)})
 
 (defn skip-page
   [page-title]
   (> (count
-       (filter #(s/includes?
-                  (s/upper-case page-title)
-                  (s/upper-case %)) (:skip-pages (:confluence cfg/config)))) 0))
+      (filter #(s/includes?
+                (s/upper-case page-title)
+                (s/upper-case %)) (:skip-pages (:confluence cfg/config)))) 0))
 
 (defn table-html
   [html]
-  (let [ first-table    (str (first (s/split html #"</table>")) "</table>")
-         after-h1-title (s/split first-table #"<h1>Attendees</h1>")
-         after-h2-title (s/split first-table #"<h2>Attendees</h2>")]
+  (let [ first-table   (str (first (s/split html #"</table>")) "</table>")
+        after-h1-title (s/split first-table #"<h1>Attendees</h1>")
+        after-h2-title (s/split first-table #"<h2>Attendees</h2>")]
     (let [payload (if (> (count after-h1-title) 1)
                     (second after-h1-title)
                     (if (> (count after-h2-title) 1)
                       (second after-h2-title)))]
       (if (and
-            payload
-            (s/starts-with? (s/trim payload) "<table"))
+           payload
+           (s/starts-with? (s/trim payload) "<table"))
         (s/trim payload)))))
 
 (defn resolve-user
   [element]
   (let [ user-element (sel/select (sel/descendant (sel/tag (keyword "ri:user"))) element)
-         select-leaf  (sel/not (sel/has-child sel/any))]
+        select-leaf   (sel/not (sel/has-child sel/any))]
     (if (not-empty user-element)
       (let [ user-key (get (:attrs (first user-element)) (keyword "ri:userkey"))
-             body     (:body (cfl/cget (str "user?expand=email&key=" user-key)))]
+            body      (:body (cfl/cget (str "user?expand=email&key=" user-key)))]
         [(:email body) (:displayName body)])
       (if-let [name (:content (first (sel/select select-leaf element)))]
         [nil (parse-string (apply str name))]
@@ -107,96 +106,96 @@
 
 (defn row-to-user
   [row program activity type meeting-date]
-  (let [ items       (sel/select (sel/child (sel/tag :tr) (sel/tag :td)) row)
-         id          (resolve-user (first items))
-         email       (first id)
-         name        (parse-string (parse-name (second id) (:remove-from-names (:confluence cfg/config))))
-         orgItem     (second items)
-         select-leaf (sel/not (sel/has-child sel/any))
-         org         (or
-                       (apply str (:content (first (sel/select sel/last-child orgItem))))
-                       (apply str (:content (first (sel/select select-leaf orgItem)))))
-         ghid        (if (> (count items) 2) (:content (first (sel/select select-leaf (nth items 2)))) nil)
-         user-by-md  (md/person-metadata-by-fn nil name email)]
+  (let [ items      (sel/select (sel/child (sel/tag :tr) (sel/tag :td)) row)
+        id          (resolve-user (first items))
+        email       (first id)
+        name        (parse-string (parse-name (second id) (:remove-from-names (:confluence cfg/config))))
+        orgItem     (second items)
+        select-leaf (sel/not (sel/has-child sel/any))
+        org         (or
+                     (apply str (:content (first (sel/select sel/last-child orgItem))))
+                     (apply str (:content (first (sel/select select-leaf orgItem)))))
+        ghid        (if (> (count items) 2) (:content (first (sel/select select-leaf (nth items 2)))) nil)
+        user-by-md  (md/person-metadata-by-fn nil name email)]
     ;; (if-not (s/blank? name)
     ;;     (let []
     ;;         (println (str
     ;;             "'" name "' '" org "' '" ghid
     ;;             "(" (Character/codePointAt name (dec (count name))) ")"))))
     (if-not (or
-              (some #(= name %) (:ignore-names (:confluence cfg/config)))
-              (and
-                (s/blank? name)
-                (s/blank? org)
-                (s/blank? ghid))) {
-                                    :email        (or
-                                                    (first (:email-addresses user-by-md))
-                                                    (first id))
-                                    :name         (or
-                                                    (:full-name user-by-md)
-                                                    name)
-                                    :org          (or
-                                                    (:organization-name (first (md/current-affiliations (:person-id user-by-md))))
-                                                    org)
-                                    :ghid         (or
-                                                    (first (:github-logins user-by-md)))
-                                    ;; TODO - cannot rely on GitHub data as third column;
-                                    ;; right now it contains all sorts of data
-                                    ;; ghid)
-                                    :program      program
-                                    :activity     activity
-                                    :type         type
-                                    :meeting-date meeting-date}
-      nil)))
+             (some #(= name %) (:ignore-names (:confluence cfg/config)))
+             (and
+              (s/blank? name)
+              (s/blank? org)
+              (s/blank? ghid))) {
+                                 :email        (or
+                                                (first (:email-addresses user-by-md))
+                                                (first id))
+                                 :name         (or
+                                                (:full-name user-by-md)
+                                                name)
+                                 :org          (or
+                                                (:organization-name (first (md/current-affiliations (:person-id user-by-md))))
+                                                org)
+                                 :ghid         (or
+                                                (first (:github-logins user-by-md)))
+                                 ;; TODO - cannot rely on GitHub data as third column;
+                                 ;; right now it contains all sorts of data
+                                 ;; ghid)
+                                 :program      program
+                                 :activity     activity
+                                 :type         type
+                                 :meeting-date meeting-date}
+            nil)))
 
 (defn meeting-roster
   [table-html page-title program activity type]
   (let [meeting-date (parse-date page-title)
-         selector    (sel/tag :tr)]
+        selector     (sel/tag :tr)]
     (let [table (html/as-hickory (html/parse table-html))
-           rows (sel/select selector table)]
+          rows  (sel/select selector table)]
       (map
-        #(row-to-user % program activity type meeting-date)
-        rows))))
+       #(row-to-user % program activity type meeting-date)
+       rows))))
 
 (defn parse-page
   [page-data program activity type]
   (let [content (cfl/content (:id page-data))
-         title  (:title page-data)]
+        title   (:title page-data)]
     (if-not (skip-page title)
       (let [table-html (table-html (cfl/content (:id page-data)))]
         (if-not (empty? table-html)
           (meeting-roster
-            table-html
-            title
-            program
-            activity
-            type)))
+           table-html
+           title
+           program
+           activity
+           type)))
       [])))
 
 (defn ids-and-titles
   [id]
   (let [children (map #(id-and-title %) (cfl/children id))]
     (flatten
-      (concat
-        children
-        (map #(ids-and-titles (:id %)) children)))))
+     (concat
+      children
+      (map #(ids-and-titles (:id %)) children)))))
 
 (defn meetings-rosters
   [program activity type url]
   (println (str "Generating meeting attendance for activity " activity))
-  (let [page-id    (cfl/page-id url)
-         sub-pages (ids-and-titles page-id)]
+  (let [page-id   (cfl/page-id url)
+        sub-pages (ids-and-titles page-id)]
     (remove nil? (flatten (map
-                            #(parse-page % program activity type)
-                            sub-pages)))))
+                           #(parse-page % program activity type)
+                           sub-pages)))))
 
 (defn roster-to-csv
   [roster-data]
   (with-open [writer (io/writer "finos-meetings.csv")]
     (.write writer "email, name, org, github ID, cm_program, cm_title, cm_type, date\n")
     (doall
-      (map
-        #(.write writer (str (s/join ", " (vals %)) "\n"))
-        roster-data))
+     (map
+      #(.write writer (str (s/join ", " (vals %)) "\n"))
+      roster-data))
     (.flush writer)))

--- a/src/metadata_tool/tools/reports.clj
+++ b/src/metadata_tool/tools/reports.clj
@@ -1,99 +1,101 @@
-;
-; Copyright 2017 Fintech Open Source Foundation
-; SPDX-License-Identifier: Apache-2.0
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
+;;
+;; Copyright 2017 Fintech Open Source Foundation
+;; SPDX-License-Identifier: Apache-2.0
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");;
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
 (ns metadata-tool.tools.reports
-  (:require [clojure.string                 :as s]
-            [clojure.tools.logging          :as log]
-            [clj-http.client                :as http]
-            [clojure.set                    :as set]
-            [mount.core                     :as mnt :refer [defstate]]
-            [clj-time.core                  :as tm]
-            [clj-time.format                :as tf]
-            [postal.core                    :as email]
-            [metadata-tool.config           :as cfg]
-            [metadata-tool.template         :as tem]
-            [metadata-tool.sources.github   :as gh]
-            [metadata-tool.sources.metadata :as md]
-            [metadata-tool.sources.bitergia :as bi]
-            [metadata-tool.sources.joins    :as j]))
+  (:require
+    [clojure.string                 :as s]
+    [clojure.tools.logging          :as log]
+    [clj-http.client                :as http]
+    [clojure.set                    :as set]
+    [mount.core                     :as mnt :refer [defstate]]
+    [clj-time.core                  :as tm]
+    [clj-time.format                :as tf]
+    [postal.core                    :as email]
+    [metadata-tool.config           :as cfg]
+    [metadata-tool.template         :as tem]
+    [metadata-tool.sources.github   :as gh]
+    [metadata-tool.sources.metadata :as md]
+    [metadata-tool.sources.bitergia :as bi]
+    [metadata-tool.sources.joins    :as j]))
 
 (def ^:private inactive-project-threshold-days 180)   ; The threshold (days) at which a project is considered "inactive"
 (def ^:private old-pr-threshold-days           60)    ; The threshold (days) at which a PR is considered "old"
 (def ^:private old-issue-threshold-days        90)    ; The threshold (days) at which an issue is considered "old"
 
 (defstate email-config
-          :start (:email cfg/config))
+  :start (:email cfg/config))
 
 (defstate email-user
-          :start (:user email-config))
+  :start (:user email-config))
 
 (defstate email-override
-          :start (:email-override cfg/config))
+  :start (:email-override cfg/config))
 
 (defstate test-email-address
-          :start (:test-email-address email-config))
+  :start (:test-email-address email-config))
 
 (def ^:private program-liaison-email-address "program-liaison@finos.org")
 
 (defn- send-email
   "Sends a UTF8 HTML email to the given to-addresses (which can be either a string or a vector of strings)."
   [to-addresses subject body & { :keys [ cc-addresses from-address reply-to-address ]
-                                   :or { from-address      email-user
-                                         reply-to-address  email-user }}]
-    (let [[to-addresses cc-addresses from-address reply-to-address]
-            (if email-override
-              [to-addresses       cc-addresses from-address       reply-to-address]      ; Only use the passed in values if the --email-override switch has been provided
-              [test-email-address nil          test-email-address test-email-address])]  ; Otherwise use the test email address throughout
-      (log/info "Sending email to" to-addresses "with subject:" subject)
-      (email/send-message email-config
-                          { :from     from-address
-                            :reply-to reply-to-address
-                            :to       to-addresses
-                            :cc       cc-addresses
-                            :subject  subject
-                            :body     [{ :type    "text/html; charset=\"UTF-8\""
-                                         :content body }] } )))
+                                 :or   { from-address     email-user
+                                         reply-to-address email-user }}]
+  (let [[to-addresses cc-addresses from-address reply-to-address]
+         (if email-override
+           [to-addresses       cc-addresses from-address       reply-to-address]      ; Only use the passed in values if the --email-override switch has been provided
+           [test-email-address nil          test-email-address test-email-address])]  ; Otherwise use the test email address throughout
+    (log/info "Sending email to" to-addresses "with subject:" subject)
+    (email/send-message email-config
+      { :from     from-address
+        :reply-to reply-to-address
+        :to       to-addresses
+        :cc       cc-addresses
+        :subject  subject
+        :body     [{ :type    "text/html; charset=\"UTF-8\""
+                     :content body }] } )))
 
 (defn- activity-stale?
   [activity stale-date]
-  (let [program-id (:program cfg/config)
-        activity-date (tf/parse (tf/formatters :date) (:contribution-date activity))
-        compare-date (compare stale-date activity-date)]
+  (let [ program-id    (:program cfg/config)
+         activity-date (tf/parse (tf/formatters :date) (:contribution-date activity))
+         compare-date  (compare stale-date activity-date)]
     (and (pos? compare-date) (= "INCUBATING" (:state activity)))))
 
 (defn- send-email-to-pmc
   [program-id subject body]
-  ; TODO - enable code below and comment out print commands!
-  ; (println "===========================")
-  ; (println subject)
-  ; (println "---------------------------")
-  ; (println body)
-  ; (println "==========================="))
+  ;; TODO - enable code below and comment out print commands!
+  ;; (println "===========================")
+  ;; (println subject)
+  ;; (println "---------------------------")
+  ;; (println body)
+  ;; (println "==========================="))
   (if-not (s/blank? program-id)
     (send-email (:pmc-mailing-list-address (md/program-metadata program-id))
-                subject
-                body
-                :cc-addresses     program-liaison-email-address
-                :reply-to-address program-liaison-email-address)))
+      subject
+      body
+      :cc-addresses     program-liaison-email-address
+      :reply-to-address program-liaison-email-address)))
 
 (defn participation-img
   [type program]
-  (let [program-id (:id program)
-        short-name (:program-short-name program)
-        img-url    (str 
+  (let [program-id  (:id program)
+         short-name (:program-short-name program)
+         img-url    (str
                       "https://raw.githubusercontent.com/finos/reports-job/master/active-participation-reports/"
                       (s/lower-case short-name)
                       "-"
@@ -107,73 +109,72 @@
 
 (defn email-pmc-reports
   []
-  (let [now-str                                          (tf/unparse (tf/formatter "yyyy-MM-dd h:mmaa ZZZ") (tm/now))
-        all-programs                                     (md/programs-metadata)
-        six-months-ago                                   (tm/minus (tm/now) (tm/months 6))
-        
-        unarchived-activities-without-leads              (group-by :program-id
-                                                                   (remove #(= "ARCHIVED" (:state %))
-                                                                     (filter #(s/blank? (:lead-or-chair-person-id %))
-                                                                       (md/activities-metadata))))
-        inactive-unarchived-activities-metadata          (group-by :program-id
-                                                                   (remove #(= "ARCHIVED" (:state %))
-                                                                           (remove nil?
-                                                                                   (map md/activity-metadata-by-name
-                                                                                        (bi/inactive-projects inactive-project-threshold-days)))))
-        stale-incubating-activities-metadata             (group-by :program-id
-                                                                    (filter #(activity-stale? % six-months-ago)
-                                                                            (md/activities-metadata)))
-        unarchived-activities-with-unactioned-prs        (group-by :program-id
-                                                                   (remove #(= "ARCHIVED" (:state %))
-                                                                           (remove nil?
-                                                                                   (map md/activity-metadata-by-name
-                                                                                        (bi/projects-with-old-prs old-pr-threshold-days)))))
-        unarchived-activities-with-unactioned-issues     (group-by :program-id
-                                                                   (remove #(= "ARCHIVED" (:state %))
-                                                                           (remove nil?
-                                                                                   (map md/activity-metadata-by-name
-                                                                                        (bi/projects-with-old-issues old-issue-threshold-days)))))
-        unarchived-activities-with-non-standard-licenses (group-by :program-id
-                                                                   (filter #(some identity (map (fn [gh-url]
-                                                                                                  (let [gh-repo-license (s/lower-case (str (:spdx_id (:license (gh/repo gh-url)))))]  ; Note underscore in :spdx_id!
-                                                                                                    (and (not= gh-repo-license "apache-2.0")
-                                                                                                         (not= gh-repo-license "cc-by-4.0" ))))
-                                                                                                (:github-urls %)))
-                                                                           (remove #(= "ARCHIVED" (:state %)) (md/activities-metadata))))
-        archived-activities-that-arent-github-archived   (group-by :program-id
-                                                                   (remove #(some identity
-                                                                                  (map (fn [gh-url] (:archived (gh/repo gh-url)))
-                                                                                       (:github-urls %)))
-                                                                           (filter #(and (= "ARCHIVED" (:state %))
-                                                                                         (pos? (count (:github-urls %))))
-                                                                                   (md/activities-metadata))))
-        activities-with-repos-without-issues-support     (group-by :program-id
-                                                                   (filter #(some identity (map (fn [gh-url] (not (:has_issues (gh/repo gh-url))))  ; Note underscore in :has_issues!
-                                                                                                (:github-urls %)))
-                                                                           (md/activities-metadata)))
-        ]
+  (let [ now-str        (tf/unparse (tf/formatter "yyyy-MM-dd h:mmaa ZZZ") (tm/now))
+         all-programs   (md/programs-metadata)
+         six-months-ago (tm/minus (tm/now) (tm/months 6))
+
+         unarchived-activities-without-leads              (group-by :program-id
+                                                            (remove #(= "ARCHIVED" (:state %))
+                                                              (filter #(s/blank? (:lead-or-chair-person-id %))
+                                                                (md/activities-metadata))))
+         inactive-unarchived-activities-metadata          (group-by :program-id
+                                                            (remove #(= "ARCHIVED" (:state %))
+                                                              (remove nil?
+                                                                (map md/activity-metadata-by-name
+                                                                  (bi/inactive-projects inactive-project-threshold-days)))))
+         stale-incubating-activities-metadata             (group-by :program-id
+                                                            (filter #(activity-stale? % six-months-ago)
+                                                              (md/activities-metadata)))
+         unarchived-activities-with-unactioned-prs        (group-by :program-id
+                                                            (remove #(= "ARCHIVED" (:state %))
+                                                              (remove nil?
+                                                                (map md/activity-metadata-by-name
+                                                                  (bi/projects-with-old-prs old-pr-threshold-days)))))
+         unarchived-activities-with-unactioned-issues     (group-by :program-id
+                                                            (remove #(= "ARCHIVED" (:state %))
+                                                              (remove nil?
+                                                                (map md/activity-metadata-by-name
+                                                                  (bi/projects-with-old-issues old-issue-threshold-days)))))
+         unarchived-activities-with-non-standard-licenses (group-by :program-id
+                                                            (filter #(some identity (map (fn [gh-url]
+                                                                                           (let [gh-repo-license (s/lower-case (str (:spdx_id (:license (gh/repo gh-url)))))]  ; Note underscore in :spdx_id!
+                                                                                             (and (not= gh-repo-license "apache-2.0")
+                                                                                               (not= gh-repo-license "cc-by-4.0" ))))
+                                                                                      (:github-urls %)))
+                                                              (remove #(= "ARCHIVED" (:state %)) (md/activities-metadata))))
+         archived-activities-that-arent-github-archived   (group-by :program-id
+                                                            (remove #(some identity
+                                                                       (map (fn [gh-url] (:archived (gh/repo gh-url)))
+                                                                         (:github-urls %)))
+                                                              (filter #(and (= "ARCHIVED" (:state %))
+                                                                         (pos? (count (:github-urls %))))
+                                                                (md/activities-metadata))))
+         activities-with-repos-without-issues-support     (group-by :program-id
+                                                            (filter #(some identity (map (fn [gh-url] (not (:has_issues (gh/repo gh-url))))  ; Note underscore in :has_issues!
+                                                                                      (:github-urls %)))
+                                                              (md/activities-metadata)))
+         ]
     (doall (map #(send-email-to-pmc (:program-id %)
-                                    (str (:program-short-name %) " PMC Report as at " now-str)
-                                    (tem/render "emails/pmc-report.ftl"
-                                                { :now                                              now-str
-                                                  :inactive-days                                    inactive-project-threshold-days
-                                                  :old-pr-threshold-days                            old-pr-threshold-days
-                                                  :old-issue-threshold-days                         old-issue-threshold-days
-                                                  :program                                          %
-                                                  :wg-participation-img                             (participation-img "working_group" %)
-                                                  :project-participation-img                        (participation-img "project" %)
-                                                  :working-groups                                   (md/activities % "WORKING_GROUP")
-                                                  :projects                                         (md/activities % "PROJECT")
-                                                  :pmc-lead                                         (md/pmc-lead %)
-                                                  :orgs-in-pmc                                      (md/orgs-in-pmc %)
-                                                  :pmc-list                                         (md/pmc-list %)
-                                                  :unarchived-activities-without-leads              (seq (sort-by :activity-name (get unarchived-activities-without-leads              (:program-id %))))
-                                                  :inactive-activities                              (seq (sort-by :activity-name (get inactive-unarchived-activities-metadata          (:program-id %))))
-                                                  :stale-activities                                 (seq (sort-by :activity-name (get stale-incubating-activities-metadata             (:program-id %))))
-                                                  :activities-with-unactioned-prs                   (seq (sort-by :activity-name (get unarchived-activities-with-unactioned-prs        (:program-id %))))
-                                                  :activities-with-unactioned-issues                (seq (sort-by :activity-name (get unarchived-activities-with-unactioned-issues     (:program-id %))))
-                                                  :unarchived-activities-with-non-standard-licenses (seq (sort-by :activity-name (get unarchived-activities-with-non-standard-licenses (:program-id %))))
-                                                  :archived-activities-that-arent-github-archived   (seq (sort-by :activity-name (get archived-activities-that-arent-github-archived   (:program-id %))))
-                                                  :activities-with-repos-without-issues-support     (seq (sort-by :activity-name (get activities-with-repos-without-issues-support     (:program-id %))))
-                                                } ))
-                all-programs))))
+                   (str (:program-short-name %) " PMC Report as at " now-str)
+                   (tem/render "emails/pmc-report.ftl"
+                     { :now                                              now-str
+                       :inactive-days                                    inactive-project-threshold-days
+                       :old-pr-threshold-days                            old-pr-threshold-days
+                       :old-issue-threshold-days                         old-issue-threshold-days
+                       :program                                          %
+                       :wg-participation-img                             (participation-img "working_group" %)
+                       :project-participation-img                        (participation-img "project" %)
+                       :working-groups                                   (md/activities % "WORKING_GROUP")
+                       :projects                                         (md/activities % "PROJECT")
+                       :pmc-lead                                         (md/pmc-lead %)
+                       :orgs-in-pmc                                      (md/orgs-in-pmc %)
+                       :pmc-list                                         (md/pmc-list %)
+                       :unarchived-activities-without-leads              (seq (sort-by :activity-name (get unarchived-activities-without-leads              (:program-id %))))
+                       :inactive-activities                              (seq (sort-by :activity-name (get inactive-unarchived-activities-metadata          (:program-id %))))
+                       :stale-activities                                 (seq (sort-by :activity-name (get stale-incubating-activities-metadata             (:program-id %))))
+                       :activities-with-unactioned-prs                   (seq (sort-by :activity-name (get unarchived-activities-with-unactioned-prs        (:program-id %))))
+                       :activities-with-unactioned-issues                (seq (sort-by :activity-name (get unarchived-activities-with-unactioned-issues     (:program-id %))))
+                       :unarchived-activities-with-non-standard-licenses (seq (sort-by :activity-name (get unarchived-activities-with-non-standard-licenses (:program-id %))))
+                       :archived-activities-that-arent-github-archived   (seq (sort-by :activity-name (get archived-activities-that-arent-github-archived   (:program-id %))))
+                       :activities-with-repos-without-issues-support     (seq (sort-by :activity-name (get activities-with-repos-without-issues-support     (:program-id %))))}))
+             all-programs))))


### PR DESCRIPTION
- styleguide would prefer 2 spaces, but let's not change it yet
- added `.dir-locals.el` for Emacs users
- use double semicolon `;;` instead of single semicolon `;` for beginning-of-line comments (part of an [old lisp tradition](http://www.lispworks.com/documentation/HyperSpec/Body/02_ddb.htm))