### PR TITLE
activity.json schema 1.2.0 allows to define a gitHubOrg field, to ove…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                          [hickory                               "0.7.1"]
                          [lambdaisland/uri                      "1.1.0"]
                          [com.github.grinnbearit/freemarker-clj "-SNAPSHOT"]
-                         [metosin/scjsv                         "0.6.0"]
+                         [metosin/scjsv                         "0.5.0"]
                          [clj-jgit                              "0.8.10" :exclusions [org.apache.httpcomponents/httpclient]]
                          [irresponsible/tentacles               "0.6.6"]
                          [cc.qbits/spandex                      "0.7.4" :exclusions [commons-logging org.apache.httpcomponents/httpcore-nio]]

--- a/src/metadata_tool/sources/metadata.clj
+++ b/src/metadata_tool/sources/metadata.clj
@@ -207,13 +207,19 @@
   [program-id]
   (sort (map #(.getName ^java.io.File %) (list-subdirs (io/file (str program-metadata-directory "/" program-id))))))
 
+(defn- get-gh-org
+  [activity-gh-org program]
+  (if activity-gh-org
+    activity-gh-org
+    (:github-org program)))
+
 (defn- github-urls
-  [program repos]
-  (seq (map #(str "https://github.com/" (:github-org program) "/" %) repos)))
+  [program repos & [activity-gh-org]]
+  (seq (map #(str "https://github.com/" (get-gh-org activity-gh-org program) "/" %) repos)))
 
 (defn- program-activity-github-urls
   [program activity]
-  (github-urls program (:github-repos activity)))
+  (github-urls program (:github-repos activity) (:github-org activity)))
 
 (defn- pmc-github-urls
   [program]


### PR DESCRIPTION
…rride the one defined at program level