### PR TITLE
Security and quality reporting (using GitHub Issues)

### DIFF
--- a/src/metadata_tool/sources/github.clj
+++ b/src/metadata_tool/sources/github.clj
@@ -183,7 +183,7 @@
   (map :login (committers repo-url)))
 
 (defn issues-fn
-  "Returns all issues across all repos of a given org (max 100)"
+  "Returns first 100 open issues, with a given label, across all repos of a given org"
   [org-name label]
   (let [issues (:items (ts/search-issues ""
                                  {:label (str "\"" label "\"")

--- a/src/metadata_tool/sources/github.clj
+++ b/src/metadata_tool/sources/github.clj
@@ -23,7 +23,7 @@
             [clj-jgit.porcelain    :as git]
             [clj-http.client       :as http]
             [tentacles.repos       :as tr]
-            [tentacles.issues      :as ti]
+            [tentacles.search      :as ts]
             [tentacles.orgs        :as to]
             [tentacles.users       :as tu]
             [metadata-tool.config  :as cfg]))
@@ -182,15 +182,15 @@
   [repo-url]
   (map :login (committers repo-url)))
 
-(defn issues
-  "List repository issue, optionally filtering by label"
-  [repo-url & [labels]]
-  (let [[org repo] (parse-github-url-path repo-url)
-        label-opts (assoc opts :labels labels)
-        issues (call-gh (ti/issues org repo label-opts))]
-    ; (println "Issues for repo" org "/" repo "-" (count issues))
-    ; (println label-opts)
+(defn issues-fn
+  "Returns all issues across all repos of a given org (max 100)"
+  [org-name label]
+  (let [issues (:items (ts/search-issues ""
+                                 {:label (str "\"" label "\"")
+                                  :state "open"
+                                  :org org-name} opts))]
     issues))
+(def issues (memoize issues-fn))
 
 (defn- org-fn
   "Returns information on the given org, or nil if it doesn't exist."


### PR DESCRIPTION
implemented reporting/notifications for labels:
- `security vulnerability` (whitesource)
- `quality checks` (project compliance and quality action)

The `check-github-issues` is invoked by `check-remote` and reports all repos having issues with labels mentioned above.

The GitHub API call is done org-wide, to avoid hitting API rate limit.

Delivers part of the `Quality, security and legal reporting/notifications`
 ODP epic -  https://github.com/finos/open-developer-platform/issues/33